### PR TITLE
Update front page and last page format of CS proposal

### DIFF
--- a/pages/proposal/cover.tex
+++ b/pages/proposal/cover.tex
@@ -36,7 +36,8 @@
     \begin{center}
         \bfseries \zihao{3}
         \begin{tabularx}{.7\textwidth}{>{\fangsong}l >{\fangsong}X<{\centering}}
-            姓名与学号 & \uline{\hfill} \\
+            学生姓名 & \uline{\hfill} \\
+            学生学号 & \uline{\hfill} \\
             指导教师   & \uline{\hfill} \\
             年级与专业 & \uline{\hfill} \\
             所在学院   & \uline{\hfill} \\
@@ -48,7 +49,8 @@
     \begin{center}
         \bfseries \zihao{3}
         \begin{tabularx}{.7\textwidth}{>{\fangsong}l >{\fangsong}X<{\centering}}
-            姓名与学号 & \uline{\hfill \StudentName~\StudentID \hfill} \\
+            学生姓名 & \uline{\hfill \StudentName \hfill} \\
+            学生学号 & \uline{\hfill \StudentID \hfill} \\
             指导教师   & \uline{\hfill \AdvisorName \hfill}            \\
             年级与专业 & \uline{\hfill \mbox{\Grade}级\Major \hfill}   \\
             所在学院   & \uline{\hfill \Department \hfill}             \\

--- a/pages/proposal/thesis/proposaleval.tex
+++ b/pages/proposal/thesis/proposaleval.tex
@@ -6,11 +6,18 @@
 
     {
         \zihao{4}
-        \noindent 对文献综述、外文翻译和开题报告评语及成绩评定：
+        \noindent 导师对开题报告、外文翻译和文献综述的评语及成绩评定：
     }
-
-
     \mbox{} \vfill
     \thesisproposaleval
-    \signature{开题报告答辩小组负责人（签名）}
+    \signature{导师签名}
+
+    \bfseries
+    {
+        \zihao{4}
+        \noindent 学院盲审专家对开题报告、外文翻译和文献综述的评语及成绩评定：
+    }
+    \mbox{} \vfill
+    \thesisproposaleval
+    \signature{开题报告审核负责人（签名/签章）}
 }


### PR DESCRIPTION
今年计算机学院计算机科学的开题报告格式（首页和尾页）和原来的模板有所不同，数媒似乎还是一样的。更新了一下新的首页尾页，建议新开一个分支。
[新模板参见](http://cspo.zju.edu.cn/cspo_bks/content.php?id=8694)