### PR TITLE
use physics package for Dirac bracket

### DIFF
--- a/config/format/major/physics/commands.tex
+++ b/config/format/major/physics/commands.tex
@@ -1,4 +1,2 @@
-\newcommand{\bra}[1]{\langle{#1}\vert}
-\newcommand{\ket}[1]{\vert{#1}\rangle}
-\newcommand{\inner}[2]{\langle{#1}\vert{#2}\rangle}
-\newcommand{\obser}[3]{\langle{#1}\vert{#2}\vert{#3}\rangle}
+\newcommand{\inner}{\innerproduct}
+\newcommand{\obser}{\matrixelement}

--- a/config/format/major/physics/packages.tex
+++ b/config/format/major/physics/packages.tex
@@ -1,2 +1,3 @@
 \usepackage{amsmath}
 \usepackage{bm}
+\usepackage{physics}


### PR DESCRIPTION
`physics`包提供了对Dirac bracket（量子力学常用）的支持，比原来在`commands.tex`中定义的命令更规范且支持更多种Dirac bracket。

同时为了照顾已使用原命令的人，做了兼容。