### PR TITLE
[xuyinda/fixup] fix omitting SubmitDate on the cover of graduate thesis

### DIFF
--- a/page/graduate/cover-chn.tex
+++ b/page/graduate/cover-chn.tex
@@ -86,6 +86,6 @@
 \begin{center}
     \zihao{-3} \bfseries
     \begin{tabularx}{.5\textwidth}{>{\fangsong}l >{\fangsong}X<{\centering}}
-        论文递交日期 & \uline{\hfill}
+        论文递交日期 & \uline{\SubmitDate}
     \end{tabularx}
 \end{center}


### PR DESCRIPTION
修复研究生模版中SubmitDate缺失的bug

删除 \hfil (否则提交日期会被换行）