### PR TITLE
fix: cover lines position shifting

### DIFF
--- a/page/undergraduate/proposal/cover.tex
+++ b/page/undergraduate/proposal/cover.tex
@@ -36,11 +36,11 @@
         \begin{tabularx}{.7\textwidth}{>{\fangsong}l >{\fangsong}X<{\centering}}
             \ifthenelse{\equal{\MajorFormat}{cs}}%
             {%
-                学生姓名   & \uline{\hfill} \vspace{10.5pt}\\
-                学生学号   & \uline{\hfill} \vspace{10.5pt}\\
-                指导教师   & \uline{\hfill} \vspace{10.5pt}\\
-                年级与专业 & \uline{\hfill} \vspace{10.5pt}\\
-                所在学院   & \uline{\hfill} \vspace{10.5pt}\\
+                \vspace{10.5pt} 学生姓名   & \uline{\hfill} \\
+                \vspace{10.5pt} 学生学号   & \uline{\hfill} \\
+                \vspace{10.5pt} 指导教师   & \uline{\hfill} \\
+                \vspace{10.5pt} 年级与专业 & \uline{\hfill} \\
+                所在学院   & \uline{\hfill} \\
             }
             {%
                 姓名与学号 & \uline{\hfill} \\
@@ -58,11 +58,11 @@
         \begin{tabularx}{.7\textwidth}{>{\fangsong}l >{\fangsong}X<{\centering}}
             \ifthenelse{\equal{\MajorFormat}{cs}}%
             {%
-                学生姓名 & \uline{\hfill \StudentName \hfill} \vspace{10.5pt}\\
-                学生学号 & \uline{\hfill \StudentID \hfill} \vspace{10.5pt}\\
-                指导教师   & \uline{\hfill \AdvisorName \hfill} \vspace{10.5pt}\\
-                年级与专业 & \uline{\hfill \mbox{\Grade}级\Major \hfill} \vspace{10.5pt}\\
-                所在学院   & \uline{\hfill \Department \hfill} \vspace{10.5pt}\\
+                \vspace{10.5pt} 学生姓名   & \uline{\hfill \StudentName \hfill} \\
+                \vspace{10.5pt} 学生学号   & \uline{\hfill \StudentID \hfill} \\
+                \vspace{10.5pt} 指导教师   & \uline{\hfill \AdvisorName \hfill} \\
+                \vspace{10.5pt} 年级与专业 & \uline{\hfill \mbox{\Grade}级\Major \hfill} \\
+                所在学院   & \uline{\hfill \Department \hfill} \\
             }
             {%
                 姓名与学号 & \uline{\hfill \StudentName~\StudentID \hfill} \\


### PR DESCRIPTION
在上一次的PR中，于每行末尾添加vspace，但出现了横线与对应属性名称偏移的BUG（十分抱歉，未做到仔细检查），虽然尚不明确原因，但将vspace挪动至开端解决了此问题。

![image](https://user-images.githubusercontent.com/44400703/111756537-49a69e80-88d5-11eb-8459-4342c7f9cfa0.png)

vspace个人理解为在该行结束后产生垂直空白，不明白为何在行首行尾产生了不同的影响，而用 \\[10.5pt] 形式命令断行控制间距则会导致文字右对齐，所以选择了这样的修改。