### PR TITLE
fix cs undergraduate toc format error

### DIFF
--- a/config/format/major/cs/layout.tex
+++ b/config/format/major/cs/layout.tex
@@ -28,9 +28,9 @@
     \setlength{\cftsubsubsecindent} {2em}
 }
 {
-    \ifthenelse{\equal}{\Period}{proposal}
+    \ifthenelse{\equal{\Period}{proposal}}
     {
-        \ifthenelse{\equal}{\Type}{thesis}
+        \ifthenelse{\equal{\Type}{thesis}}
         {
             \renewcommand{\cftchapfont}         {\bfseries\zihao{-4}}
             \renewcommand{\cftsecfont}          {\bfseries\zihao{-4}}


### PR DESCRIPTION
此前commit时的低级的syntax typo。
PS：以后任何commit前一定会进行编译检查，并保持清醒:cry: :pray: