### PR TITLE
Remove bib num in toc of undergraduate-final

### DIFF
--- a/body/undergraduate/final/content.tex
+++ b/body/undergraduate/final/content.tex
@@ -4,10 +4,12 @@
 \inputbody{final/2-body}
 
 \newpage
+\defbibheading{bibliography}[\bibname]{\sectionnonum{#1}}
 \begingroup
     \linespread{1}
     \printbibliography[title={参考文献}]
 \endgroup
+\defbibheading{bibliography}[\bibname]{\section{#1}}
 
 \inputbody{final/3-appendix}
 \inputbody{final/4-cv}


### PR DESCRIPTION
根据模板去掉了毕业论文部分目录中参考文献前的序号

---

另是否考虑把毕业论文部分的章节都往上提一层级呢？毕业论文部分层级最高只用了section，没有用chapter。