### PR TITLE
fix: undergraduate cs format cover

### DIFF
--- a/page/undergraduate/final/cover.tex
+++ b/page/undergraduate/final/cover.tex
@@ -55,14 +55,8 @@
         \begin{tabularx}{.7\textwidth}{>{\fangsong}l >{\fangsong}X<{\centering}}
             \fangsong
             \CoverTitle
-            \ifthenelse{\equal{\MajorFormat}{cs}}%
-            {%
-                学生姓名 & \uline{\hfill} \\
-                学生学号 & \uline{\hfill} \\
-            }
-            {%
-                姓名与学号 & \uline{\hfill} \\
-            }
+            
+            姓名与学号 & \uline{\hfill} \\
             指导教师   &  \uline{\hfill} \\
             年级与专业  &  \uline{\hfill} \\
             所在学院   &  \uline{\hfill} \\
@@ -77,14 +71,8 @@
         \bfseries \zihao{3}
         \begin{tabularx}{.7\textwidth}{>{\fangsong}l >{\fangsong}X<{\centering}}
             \CoverTitle
-            \ifthenelse{\equal{\MajorFormat}{cs}}%
-            {%
-                学生姓名 & \uline{\hfill \StudentName \hfill} \\
-                学生学号 & \uline{\hfill \StudentID \hfill} \\
-            }
-            {%
-                姓名与学号 & \uline{\hfill \StudentName~\StudentID \hfill} \\
-            }
+            
+            姓名与学号 & \uline{\hfill \StudentName~\StudentID \hfill} \\
             指导教师   &  \uline{\hfill \AdvisorName \hfill} \\
             年级与专业  &  \uline{\hfill \mbox{\Grade}级\Major \hfill} \\
             所在学院   &  \uline{\hfill \Department \hfill} \\


### PR DESCRIPTION
CS本科生的论文封面应该与其他专业相同，“姓名与学号”在同一行。分写两行“学生姓名”“学生学号”的是开题报告的封面。