### PR TITLE
fix: split bib in review and proposal

### DIFF
--- a/body/undergraduate/proposal/proposal/proposal.tex
+++ b/body/undergraduate/proposal/proposal/proposal.tex
@@ -1,6 +1,7 @@
 \cleardoublepage
 \newrefsection
 \chapter{开题报告}
+\begin{refsection}
 
 \inputbody{proposal/proposal/background}
 \inputbody{proposal/proposal/content}
@@ -11,3 +12,4 @@
     \linespreadsingle{}
     \printbibliography[title={参考文献}]
 \endgroup
+\end{refsection}

--- a/body/undergraduate/proposal/review/review.tex
+++ b/body/undergraduate/proposal/review/review.tex
@@ -1,6 +1,7 @@
 \cleardoublepage
 \newrefsection
 \chapter{文献综述}
+\begin{refsection}
 
 \section{背景介绍}
 \par 正文格式与具体要求\cite{zjuthesisrules}
@@ -22,3 +23,4 @@
     \linespreadsingle{}
     \printbibliography[title={参考文献}]
 \endgroup
+\end{refsection}


### PR DESCRIPTION
During the blind review stage, some teachers suggested that the references of the review and the proposal should not be the same. So we make this modification.