### PR TITLE
增加电气工程学院模板(本科生)

### DIFF
--- a/body/undergraduate/final/abstract.tex
+++ b/body/undergraduate/final/abstract.tex
@@ -1,6 +1,7 @@
 \cleardoublepage{}
 \begin{center}
-    \bfseries \zihao{3} 摘要
+    \bfseries \zihao{3} 
+    \ifthenelse{\equal{\MajorFormat}{ee}}{摘~要}{摘要}
 \end{center}
 
 

--- a/body/undergraduate/final/acknowledgement.tex
+++ b/body/undergraduate/final/acknowledgement.tex
@@ -1,4 +1,5 @@
 \cleardoublepage{}
 \begin{center}
-    \bfseries \zihao{3} 致谢
+    \bfseries \zihao{3} 
+    \ifthenelse{\equal{\MajorFormat}{ee}}{致~谢}{致谢}
 \end{center}

--- a/config/commands.tex
+++ b/config/commands.tex
@@ -173,6 +173,55 @@
     \end{table}
 }
 
+\DeclareDocumentCommand{\eefinaleval}{O{~} O{~} O{~} O{~} O{~} O{~}}
+{
+  \begin{center}
+    \begin{tabular}{| >{\songti \zihao{5}}c
+                    | >{\songti \zihao{5}}c
+                    | >{\songti \zihao{5}}c
+                    | >{\songti \zihao{5}}c 
+                    | >{\songti \zihao{5}}c
+                    | >{\songti \zihao{5}}c
+                    | >{\songti \zihao{5}}c|}
+    \hline
+    \multirow{2}*{\textbf{成绩}}
+    & \textbf{文献综述}
+    & \textbf{开题报告}
+    & \textbf{外文翻译}
+    & \textbf{毕业设计（论文）质}
+    & \textbf{成果评分}
+    & \multirow{2}*{\textbf{总评成绩}} \\
+
+    \textbf{比例}
+    & \textbf{占（10\%）}
+    & \textbf{占（15\%）}
+    & \textbf{占（5\%）}
+    & \textbf{量及答辩占（62\%）}
+    & \textbf{占（8\%）}
+    & ~ \\
+
+    \hline
+
+    \multirow{2}*{分值}
+    & \multirow{2}*{\zihao{4}#1}
+    & \multirow{2}*{\zihao{4}#2}
+    & \multirow{2}*{\zihao{4}#3}
+    & \multirow{2}*{\zihao{4}#4}
+    & \multirow{2}*{\zihao{4}#5}
+    & \multirow{2}*{\zihao{4}#6} \\
+
+    ~
+    & ~
+    & ~
+    & ~ 
+    & ~ 
+    & ~ 
+    & ~ \\
+    \hline
+    \end{tabular}
+  \end{center}
+}
+
 % `design` commands
 \DeclareDocumentCommand{\designproposaleval}{O{~} O{~}}
 {

--- a/config/commands.tex
+++ b/config/commands.tex
@@ -176,13 +176,14 @@
 \DeclareDocumentCommand{\eefinaleval}{O{~} O{~} O{~} O{~} O{~} O{~}}
 {
   \begin{center}
-    \begin{tabular}{| >{\songti \zihao{5}}c
+  \begin{adjustbox}{minipage=16cm, center}
+    \begin{tabularx}{\textwidth}{| >{\songti \zihao{5}}c
                     | >{\songti \zihao{5}}c
                     | >{\songti \zihao{5}}c
                     | >{\songti \zihao{5}}c 
                     | >{\songti \zihao{5}}c
                     | >{\songti \zihao{5}}c
-                    | >{\songti \zihao{5}}c|}
+                    | >{\songti \zihao{5}}X<{\centering}|}
     \hline
     \multirow{2}*{\textbf{成绩}}
     & \textbf{文献综述}
@@ -218,7 +219,8 @@
     & ~ 
     & ~ \\
     \hline
-    \end{tabular}
+    \end{tabularx}
+  \end{adjustbox}
   \end{center}
 }
 

--- a/config/commands.tex
+++ b/config/commands.tex
@@ -129,6 +129,18 @@
     \end{flushright}
 }
 
+\newcommand{\eechecklistsig}[1]
+{
+  % For undergrad ee thesis
+    \begin{center}
+        \songti
+        \zihao{-4}
+        #1 \underline{\multido{}{7}{\quad}}
+        \multido{}{3}{\quad} 
+        检查日期：\underline{\multido{}{7}{\quad}}
+    \end{center}
+}
+
 \DeclareDocumentCommand{\finaleval}{O{~} O{~} O{~} O{~} O{~}}
 {
     \begin{table}[H]
@@ -253,6 +265,48 @@
             & ~ 
             & ~ \\
             \hline
+        \end{tabular}
+    \end{center}
+  }
+
+  % For undergrad ee thesis
+  \DeclareDocumentCommand{\eethesischecklistinfo}{O{~} O{~}}
+  {
+    \begin{center}
+      \begin{tabular}{|>{\songti \zihao{5}}l
+                      |>{\songti \zihao{5}}l
+                        >{\songti \zihao{5}}l
+                        >{\songti \zihao{5}}p{2.1cm}
+                      |>{\songti \zihao{5}}l
+                      |>{\songti \zihao{5}}p{2cm}|}
+      \hline
+      学生姓名                      & \multicolumn{1}{p{2.1cm}|}{\songti \zihao{5}\StudentName}       & \multicolumn{1}{l|}{学号} & \StudentID & 专业年级小班               &   \Class   \\ \hline
+      指导教师                      & \multicolumn{1}{l|}{\songti \zihao{5}\AdvisorName}              & \multicolumn{1}{l|}{职称} & #1         & 学生联系电话               &   \Phone   \\ \hline
+      \multirow{2}{*}{毕业设计题目}  & \multicolumn{3}{l|}{\multirow{2}{*}{\songti \zihao{5}\Title}}                                           & \multirow{2}{*}{评定成绩} & \multirow{2}{*}{#2} \\
+                                   & \multicolumn{3}{l|}{}                                                                                   &                          &                   \\ \hline
+      \end{tabular}
+    \end{center}
+  }
+
+  \DeclareDocumentCommand{\eethesischecklist}{O{~} O{~}}
+  {
+    \begin{center}
+      \begin{tabular}{|p{2cm}>{\songti \zihao{5}}p{8cm}|p{2cm}>{\songti \zihao{5}}p{1.4cm}|}
+        \hline
+        \multicolumn{2}{|c|}{\heiti\bfseries\zihao{-4}检\ 查\ 内\ 容}                                                          & \multicolumn{2}{l|}{\heiti\bfseries\zihao{-4}评价栏（打√）} \\ \hline
+        \multicolumn{1}{|p{1.5cm}|}{}                                                      & 1．封面（使用统一封面，建议蓝色）     & \multicolumn{1}{>{\songti \zihao{5}}p{1.4cm}|}{较好}    & 一般 \\ \cline{2-4} 
+        \multicolumn{1}{|l|}{}                                                             & 2．毕业设计（论文）承诺书            & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}毕}                                  & 3．致谢                           & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &      \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}业}                                  & 4．中文摘要、英文摘要（不超过 500 字） & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}设}                                  & 5．目录（每项内容要对应标注页码）      & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}计}                                  & 6．正文（从正文开始标注页码）         & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\rotatebox[origin=c]{-90}{\songti\bfseries\zihao{4}（}}       & 7．参考文献                        & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}论}                                  & 8．附录（可根据需要）                & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}文}                                  & 9．作者简介                        & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|c|}{\rotatebox[origin=c]{-90}{\songti\bfseries\zihao{4}）}}       & 10．毕业设计（论文）任务书           & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|l|}{}                                                             & 11．毕业设计（论文） 考核表          & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|l|}{}                                                             & 12．毕业设计（论文）专家评阅意见表     & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+        \multicolumn{1}{|l|}{}                                                             & 13．毕业设计（论文）现场答辩记录表     & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \hline
         \end{tabular}
     \end{center}
   }

--- a/config/commands.tex
+++ b/config/commands.tex
@@ -216,8 +216,50 @@
 }
 
 % `thesis` commands
-\DeclareDocumentCommand{\thesisproposaleval}{O{~} O{~} O{~}}
+\ifthenelse{\equal{\MajorFormat}{ee}}
 {
+  \DeclareDocumentCommand{\thesisproposaleval}{O{~} O{~} O{~} O{~}}
+  {
+    \begin{center}
+        \begin{tabular}{| >{\songti \zihao{4}}c
+                        | >{\songti \zihao{5}}c
+                        | >{\songti \zihao{5}}c
+                        | >{\songti \zihao{5}}c 
+                        | >{\songti \zihao{5}}c|}
+            \hline
+            \multirow{2}*{\ 成绩比例\ }
+            & \ \ 文献综述\ \ 
+            & \ \ 开题报告\ \ 
+            & \ \ 外文翻译\ \ 
+            & \multirow{2}*{\ \ \ \ \ 合\ \ \ \ 计\ \ \ \ \ } \\
+
+            ~
+            & 占（10\%）
+            & 占（15\%）
+            & 占（5\%）
+            & ~ \\
+
+            \hline
+
+            \multirow{2}*{\ \ 分\ \ \ 值\ \ }
+            & \multirow{2}*{\zihao{4}#1}
+            & \multirow{2}*{\zihao{4}#2}
+            & \multirow{2}*{\zihao{4}#3}
+            & \multirow{2}*{\zihao{4}#4} \\
+
+            ~
+            & ~
+            & ~
+            & ~ 
+            & ~ \\
+            \hline
+        \end{tabular}
+    \end{center}
+  }
+}
+{
+  \DeclareDocumentCommand{\thesisproposaleval}{O{~} O{~} O{~}}
+  {
     \begin{flushright}
         \begin{tabular}{| >{\fangsong \zihao{4}}c
                         | >{\fangsong \zihao{5}}c
@@ -248,6 +290,7 @@
             \hline
         \end{tabular}
     \end{flushright}
+  }
 }
 }
 {}

--- a/config/commands.tex
+++ b/config/commands.tex
@@ -321,43 +321,13 @@
   % For undergrad ee thesis
   \DeclareDocumentCommand{\eethesischecklistinfo}{O{~} O{~}}
   {
-    \begin{center}
-      \begin{tabular}{|>{\songti \zihao{5}}l
-                      |>{\songti \zihao{5}}l
-                        >{\songti \zihao{5}}l
-                        >{\songti \zihao{5}}p{2.1cm}
-                      |>{\songti \zihao{5}}l
-                      |>{\songti \zihao{5}}p{2cm}|}
+      \begin{tabularx}{\textwidth}{|X|X|X|X|X|X|}
       \hline
       学生姓名                      & \multicolumn{1}{p{2.1cm}|}{\songti \zihao{5}\StudentName}       & \multicolumn{1}{l|}{学号} & \StudentID & 专业年级小班               &   \Class   \\ \hline
       指导教师                      & \multicolumn{1}{l|}{\songti \zihao{5}\AdvisorName}              & \multicolumn{1}{l|}{职称} & #1         & 学生联系电话               &   \Phone   \\ \hline
       \multirow{2}{*}{毕业设计题目}  & \multicolumn{3}{l|}{\multirow{2}{*}{\songti \zihao{5}\Title}}                                           & \multirow{2}{*}{评定成绩} & \multirow{2}{*}{#2} \\
                                    & \multicolumn{3}{l|}{}                                                                                   &                          &                   \\ \hline
-      \end{tabular}
-    \end{center}
-  }
-
-  \DeclareDocumentCommand{\eethesischecklist}{O{~} O{~}}
-  {
-    \begin{center}
-      \begin{tabular}{|p{2cm}>{\songti \zihao{5}}p{8cm}|p{2cm}>{\songti \zihao{5}}p{1.4cm}|}
-        \hline
-        \multicolumn{2}{|c|}{\heiti\bfseries\zihao{-4}检\ 查\ 内\ 容}                                                          & \multicolumn{2}{l|}{\heiti\bfseries\zihao{-4}评价栏（打√）} \\ \hline
-        \multicolumn{1}{|p{1.5cm}|}{}                                                      & 1．封面（使用统一封面，建议蓝色）     & \multicolumn{1}{>{\songti \zihao{5}}p{1.4cm}|}{较好}    & 一般 \\ \cline{2-4} 
-        \multicolumn{1}{|l|}{}                                                             & 2．毕业设计（论文）承诺书            & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}毕}                                  & 3．致谢                           & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &      \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}业}                                  & 4．中文摘要、英文摘要（不超过 500 字） & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}设}                                  & 5．目录（每项内容要对应标注页码）      & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}计}                                  & 6．正文（从正文开始标注页码）         & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\rotatebox[origin=c]{-90}{\songti\bfseries\zihao{4}（}}       & 7．参考文献                        & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}论}                                  & 8．附录（可根据需要）                & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}文}                                  & 9．作者简介                        & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|c|}{\rotatebox[origin=c]{-90}{\songti\bfseries\zihao{4}）}}       & 10．毕业设计（论文）任务书           & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|l|}{}                                                             & 11．毕业设计（论文） 考核表          & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|l|}{}                                                             & 12．毕业设计（论文）专家评阅意见表     & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
-        \multicolumn{1}{|l|}{}                                                             & 13．毕业设计（论文）现场答辩记录表     & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \hline
-        \end{tabular}
-    \end{center}
+      \end{tabularx}
   }
 }
 {

--- a/config/format/major/ee/README.md
+++ b/config/format/major/ee/README.md
@@ -3,5 +3,15 @@
 - [ ] [page/undergraduate/final/eechecklist.tex](../../../../page/undergraduate/final/eechecklist.tex)：将`教师职称`和`分数`替换为相应内容
 - [ ] [page/undergraduate/final/eeopinion.tex](../../../../page/undergraduate/final/eeopinion.tex)：将`【这里填职称】`和`【这里填单位】`两处替换为相应内容
 - [ ] [page/undergraduate/final/eerecord.tex](../../../../page/undergraduate/final/eerecord.tex)：同上，将所有用【】包括的项目替换为相应内容。答辩记录的主体目前用空行（`~\\`）填充，如有必要请自行输入答辩记录。
+- [ ] [page/undergraduate/final/job.tex](../../../../page/undergraduate/final/job.tex)：根据学院下发的模板，将这行代码
+  ```latex
+  \noindent 起讫日期 20 \quad 年 \quad  月 \quad  日 \quad 至 \quad 20 \quad  年 \quad  月  \quad 日
+  ```
+  替换成相应的起讫日期。
+- [ ] [`body/undergraduate/final/abstract.tex`](../../../../body/undergraduate/final/abstract.tex)：学院要求中英文摘要后附加关键词，请使用以下语句
+  ```latex
+  {\noindent \textbf{关键词：} XXX、XXX、XXX、XXX}
+  {\noindent \textbf{Key words:} xxx, xxx, xxx, xxx}
+  ```
 
 如果编译后发现表格的排版混乱，这是因为某些栏目的字数过多。可以考虑用`{\zihao{6}内容}`缩小字号以腾出空间，或者自己想办法调整表格列宽，如果实在无法解决，可以通过邮件联系我，我的邮箱是zj_hu \[at\] zju.edu.cn。

--- a/config/format/major/ee/README.md
+++ b/config/format/major/ee/README.md
@@ -1,4 +1,4 @@
-使用电气工程学院毕业设计（论文）模板前，请**务必检查以下条目是否完成**：
+在提交电气工程学院毕业设计（论文）前，请**务必检查以下条目是否完成**：
 
 - [ ] [page/undergraduate/final/eechecklist.tex](../../../../page/undergraduate/final/eechecklist.tex)：将`教师职称`和`分数`替换为相应内容
 - [ ] [page/undergraduate/final/eeopinion.tex](../../../../page/undergraduate/final/eeopinion.tex)：将`【这里填职称】`和`【这里填单位】`两处替换为相应内容

--- a/config/format/major/ee/README.md
+++ b/config/format/major/ee/README.md
@@ -1,0 +1,7 @@
+使用电气工程学院毕业设计（论文）模板前，请**务必检查以下条目是否完成**：
+
+- [ ] [page/undergraduate/final/eechecklist.tex](../../../../page/undergraduate/final/eechecklist.tex)：将`教师职称`和`分数`替换为相应内容
+- [ ] [page/undergraduate/final/eeopinion.tex](../../../../page/undergraduate/final/eeopinion.tex)：将`【这里填职称】`和`【这里填单位】`两处替换为相应内容
+- [ ] [page/undergraduate/final/eerecord.tex](../../../../page/undergraduate/final/eerecord.tex)：同上，将所有用【】包括的项目替换为相应内容。答辩记录的主体目前用空行（`~\\`）填充，如有必要请自行输入答辩记录。
+
+如果编译后发现表格的排版混乱，这是因为某些栏目的字数过多。可以考虑用`{\zihao{6}内容}`缩小字号以腾出空间，或者自己想办法调整表格列宽，如果实在无法解决，可以通过邮件联系我，我的邮箱是zj_hu \[at\] zju.edu.cn。

--- a/config/format/major/ee/code.tex
+++ b/config/format/major/ee/code.tex
@@ -1,0 +1,54 @@
+\definecolor{themeblue}{RGB}{0, 63, 136}
+\definecolor{themered}{RGB}{176, 31, 36}
+
+\definecolor{codecolorkeywords}{rgb}{0,0,0}
+\definecolor{codecolorcomments}{rgb}{0.5,0.5,0.5}
+\definecolor{codecolorstrings}{rgb}{0,0,0}
+\definecolor{codecolortypes}{rgb}{0,0,0}
+
+\lstloadlanguages{
+    C,
+    C++,
+    Python,
+    Java
+}
+
+\lstdefinestyle{codestyle}{
+    % Basic design
+    basicstyle=\ttfamily,
+    frame=tb,
+    %framesep=5pt,
+    framerule=.5pt,
+    rulecolor=\color{black},
+    abovecaptionskip=0pt,
+    belowcaptionskip=5pt,
+    % Code design
+    keywordstyle=\color{codecolorkeywords},
+    commentstyle=\color{codecolorcomments},
+    stringstyle=\color{codecolorstrings},
+    numberstyle=\small\color{gray},
+    breakatwhitespace=false,
+    breaklines=true,
+    captionpos=t,
+    keepspaces=true,
+    % Line numbers
+    %numbers=left,
+    numbersep=10pt,
+    %xleftmargin=.5em,
+    stepnumber=1,
+    firstnumber=1,
+    numberfirstline=true,
+    % Code
+    tabsize=4,
+    showspaces=false,
+    showstringspaces=false,
+    showtabs=false,
+    breaklines=true,
+}
+\lstset{style=codestyle}
+
+\DeclareCaptionFormat{codecaptionformat}{%
+  \parbox{\textwidth}{\centering#1#2\hspace{.5em}#3}
+}
+\DeclareCaptionFont{songti}{\songti}
+\captionsetup[lstlisting]{format=codecaptionformat, font={bf,songti,small}}

--- a/config/format/major/ee/geometry.tex
+++ b/config/format/major/ee/geometry.tex
@@ -1,0 +1,23 @@
+% Set page layout
+\ifthenelse{\equal{\Degree}{undergraduate}}
+{
+    % Set margins according to the MS template from EE website.
+    \geometry{
+        a4paper,
+        marginpar=0pt,
+        includeheadfoot,
+        vmargin={2.54cm, 2.54cm},
+        hmargin={3.18cm, 3.18cm},
+        headsep=4mm
+    }
+}
+{
+    \geometry{
+        a4paper,
+        marginpar=0pt,
+        includeheadfoot,
+        vmargin={2.0cm, 2.0cm},
+        hmargin={2.5cm, 2.5cm},
+        headsep=4mm
+    }
+}

--- a/config/format/major/ee/heading.tex
+++ b/config/format/major/ee/heading.tex
@@ -1,0 +1,14 @@
+% ctex style settings
+\ifthenelse{\equal{\Degree}{undergraduate}}
+{
+  \ifthenelse{\equal{\Period}{final}}{
+    \ctexset
+    {
+        section = 
+        {
+            format=\flushleft\zihao{3}\bfseries,
+            name={第,章}
+        }
+    }
+  }{}
+}{}

--- a/config/format/major/ee/layout.tex
+++ b/config/format/major/ee/layout.tex
@@ -1,0 +1,23 @@
+\ifthenelse{\equal{\Degree}{graduate}}
+{}
+{
+    \ifthenelse{\equal{\Period}{proposal}}
+    {
+        \ifthenelse{\equal{\Type}{thesis}}
+        {
+            \renewcommand{\cftchapfont}         {\bfseries\zihao{-4}}
+            \renewcommand{\cftsecfont}          {\bfseries\zihao{-4}}
+            \renewcommand{\cftsubsecfont}       {\zihao{-4}}
+            \renewcommand{\cftsubsubsecfont}    {\zihao{-4}}
+        }
+        {}
+    }
+    {}
+
+    \appto{\bodystyle}{
+        \defbibheading{bibliography}[\bibname]{
+            \sectionnonum{#1}
+            \markboth{#1}{#1}
+        }
+    }
+}

--- a/config/format/major/ee/layout.tex
+++ b/config/format/major/ee/layout.tex
@@ -1,5 +1,4 @@
-\ifthenelse{\equal{\Degree}{graduate}}
-{}
+\ifthenelse{\equal{\Degree}{undergraduate}}
 {
     \ifthenelse{\equal{\Period}{proposal}}
     {
@@ -12,7 +11,11 @@
         }
         {}
     }
-    {}
+    {
+      % TODO: 
+      % 1. Set page margin in previous page style to 3.18cm
+      % 2. Cancel the header in 承诺书、致谢、摘要 and `Abstract` page
+    }
 
     \appto{\bodystyle}{
         \defbibheading{bibliography}[\bibname]{
@@ -20,4 +23,4 @@
             \markboth{#1}{#1}
         }
     }
-}
+}{}

--- a/config/format/major/ee/layout.tex
+++ b/config/format/major/ee/layout.tex
@@ -12,9 +12,11 @@
         {}
     }
     {
-      % TODO: 
-      % 1. Set page margin in previous page style to 3.18cm
-      % 2. Cancel the header in 承诺书、致谢、摘要 and `Abstract` page
+      \fancypagestyle{previous}
+      {
+          \fancyfoot{}
+          \fancyfoot[C]{\zihao{-5}\thepage}
+      }
     }
 
     \appto{\bodystyle}{

--- a/config/format/major/ee/numbering.tex
+++ b/config/format/major/ee/numbering.tex
@@ -1,4 +1,0 @@
-\renewcommand{\numberingstyle}
-{
-    \chaptermajornumbering
-}

--- a/config/format/major/ee/numbering.tex
+++ b/config/format/major/ee/numbering.tex
@@ -1,0 +1,4 @@
+\renewcommand{\numberingstyle}
+{
+    \chaptermajornumbering
+}

--- a/config/format/major/ee/packages.tex
+++ b/config/format/major/ee/packages.tex
@@ -1,0 +1,1 @@
+\usepackage{amsmath}

--- a/config/format/major/ee/packages.tex
+++ b/config/format/major/ee/packages.tex
@@ -1,1 +1,2 @@
 \usepackage{amsmath}
+\usepackage{adjustbox}

--- a/page/undergraduate/final/cover.tex
+++ b/page/undergraduate/final/cover.tex
@@ -13,12 +13,18 @@
 
 \begin{center}
     \zihao{-1} \heiti \bfseries
-    \ifthenelse{\equal{\Type}{thesis}}
+    \ifthenelse{\equal{\MajorFormat}{ee}}
     {
-        本~科~生~毕~业~论~文
+      本~科~生~毕~业~设~计~（论文）
     }
     {
-        本~科~生~毕~业~设~计
+      \ifthenelse{\equal{\Type}{thesis}}
+      {
+          本~科~生~毕~业~论~文
+      }
+      {
+          本~科~生~毕~业~设~计
+      }
     }
 \end{center}
 
@@ -61,7 +67,13 @@
             年级与专业  &  \uline{\hfill} \\
             所在学院   &  \uline{\hfill} \\
             ~ & ~\\
-            递交日期 & \uline{\hfill} \\
+            \ifthenelse{\equal{\MajorFormat}{ee}}
+            {
+              提交日期 & \uline{\hfill \SubmitDate \hfill} \\
+            }
+            {
+              递交日期 & \uline{\hfill} \\
+            }
         \end{tabularx}
     \end{center}
 }
@@ -85,7 +97,13 @@
                         &  \uline{\hfill \DepartmentLineTwo \hfill} \\
                         ~ & ~\\
             }
-            递交日期 & \uline{\hfill \SubmitDate \hfill} \\
+            \ifthenelse{\equal{\MajorFormat}{ee}}
+            {
+              提交日期 & \uline{\hfill \SubmitDate \hfill} \\
+            }
+            {
+              递交日期 & \uline{\hfill \SubmitDate \hfill} \\
+            }
         \end{tabularx}
     \end{center}
 }

--- a/page/undergraduate/final/cover.tex
+++ b/page/undergraduate/final/cover.tex
@@ -2,7 +2,9 @@
 \setcounter{page}{-1}
 
 \begin{flushright}
-    {\bfseries 涉密论文 $\square$ ~~ 公开论文 $\square$ \multido{}{6}{\quad}}
+  \ifthenelse{\equal{\MajorFormat}{ee}}  
+  {\bfseries 涉密论文 $\square$ ~~ 公开论文 $\square$ \multido{}{3}{\quad}}
+  {\bfseries 涉密论文 $\square$ ~~ 公开论文 $\square$ \multido{}{7}{\quad}}
 \end{flushright}
 
 \vskip 10mm
@@ -68,12 +70,8 @@
             所在学院   &  \uline{\hfill} \\
             ~ & ~\\
             \ifthenelse{\equal{\MajorFormat}{ee}}
-            {
-              提交日期 & \uline{\hfill \SubmitDate \hfill} \\
-            }
-            {
-              递交日期 & \uline{\hfill} \\
-            }
+            {提交日期 & \uline{\hfill \SubmitDate \hfill} \\}
+            {递交日期 & \uline{\hfill} \\}
         \end{tabularx}
     \end{center}
 }
@@ -98,12 +96,8 @@
                         ~ & ~\\
             }
             \ifthenelse{\equal{\MajorFormat}{ee}}
-            {
-              提交日期 & \uline{\hfill \SubmitDate \hfill} \\
-            }
-            {
-              递交日期 & \uline{\hfill \SubmitDate \hfill} \\
-            }
+            {提交日期 & \uline{\hfill \SubmitDate \hfill} \\}
+            {递交日期 & \uline{\hfill \SubmitDate \hfill} \\}
         \end{tabularx}
     \end{center}
 }

--- a/page/undergraduate/final/eechecklist.tex
+++ b/page/undergraduate/final/eechecklist.tex
@@ -4,15 +4,35 @@
 \vskip 25mm
 
 \begin{center}
-  {\heiti\bfseries\zihao{3} 浙江大学本科生毕业设计（论文）装订内容检查表} \\
-  \songti\zihao{5} （此表请装订在论文首页，由指导教师在答辩结束后填写）
+  {\heiti\bfseries\zihao{3} 浙江大学本科生毕业设计（论文）装订内容检查表} \\ \vskip 2mm
+  \songti\zihao{5} （此表请装订在论文首页，由指导教师在答辩结束后填写）\vskip 2mm
+  \eethesischecklistinfo[教师职称][分数]
 \end{center}
-
-\eethesischecklistinfo[教师职称][分数]
 
 \vskip 15mm
 
-\eethesischecklist
+\begin{center}
+  \begin{tabularx}{\textwidth}{|p{2cm}
+                                >{\songti \zihao{5}}X|
+                                p{2cm}
+                                >{\songti \zihao{5}}p{1.4cm}|}
+    \hline
+    \multicolumn{2}{|c|}{\heiti\bfseries\zihao{-4}检\ 查\ 内\ 容}                                                          & \multicolumn{2}{l|}{\heiti\bfseries\zihao{-4}评价栏（打√）} \\ \hline
+    \multicolumn{1}{|p{1.5cm}|}{}                                                      & 1．封面（使用统一封面，建议蓝色）     & \multicolumn{1}{>{\songti \zihao{5}}p{1.4cm}|}{较好}    & 一般 \\ \cline{2-4} 
+    \multicolumn{1}{|l|}{}                                                             & 2．毕业设计（论文）承诺书            & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}毕}                                  & 3．致谢                           & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &      \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}业}                                  & 4．中文摘要、英文摘要（不超过 500 字） & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}设}                                  & 5．目录（每项内容要对应标注页码）      & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}计}                                  & 6．正文（从正文开始标注页码）         & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\rotatebox[origin=c]{-90}{\songti\bfseries\zihao{4}（}}       & 7．参考文献                        & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}论}                                  & 8．附录（可根据需要）                & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\songti\bfseries\zihao{4}文}                                  & 9．作者简介                        & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|c|}{\rotatebox[origin=c]{-90}{\songti\bfseries\zihao{4}）}}       & 10．毕业设计（论文）任务书           & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|l|}{}                                                             & 11．毕业设计（论文） 考核表          & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|l|}{}                                                             & 12．毕业设计（论文）专家评阅意见表     & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \cline{2-4} 
+    \multicolumn{1}{|l|}{}                                                             & 13．毕业设计（论文）现场答辩记录表     & \multicolumn{1}{>{\songti \zihao{5}}l|}{}              &     \\ \hline
+    \end{tabularx}
+\end{center}
 
 \vskip 20mm
 

--- a/page/undergraduate/final/eechecklist.tex
+++ b/page/undergraduate/final/eechecklist.tex
@@ -1,0 +1,19 @@
+\thispagestyle{empty}
+\setcounter{page}{-1}
+
+\vskip 25mm
+
+\begin{center}
+  {\heiti\bfseries\zihao{3} 浙江大学本科生毕业设计（论文）装订内容检查表} \\
+  \songti\zihao{5} （此表请装订在论文首页，由指导教师在答辩结束后填写）
+\end{center}
+
+\eethesischecklistinfo[教师职称][分数]
+
+\vskip 15mm
+
+\eethesischecklist
+
+\vskip 20mm
+
+\eechecklistsig{检查人（签名）}

--- a/page/undergraduate/final/eeopinion.tex
+++ b/page/undergraduate/final/eeopinion.tex
@@ -1,0 +1,55 @@
+\thispagestyle{empty}
+\setcounter{page}{-1}
+
+\vskip 25mm
+
+\begin{center}
+  {\heiti\bfseries\zihao{-3} 浙江大学本科生毕业设计（论文）专家评阅意见表} \\
+\end{center}
+
+\songti\zihao{-4}
+\begin{center}
+  \begin{tabularx}{\textwidth}{|p{4cm}|X|}
+    \hline
+    毕业设计（论文）题目 & \Title \\ \hline
+  \end{tabularx}
+  \begin{tabularx}{\textwidth}{|p{2cm}|X|p{1.2cm}|X|p{1cm}|X|}
+    学生姓名    & \StudentName & 学~号 & \StudentID & 年级 & \Grade   \\ \hline
+  \end{tabularx}
+  \begin{tabularx}{\textwidth}{|p{2.6cm}|X|p{1cm}|X|}
+    所在学院    & \Department  & 专业 & \Major                       \\ \hline
+  \end{tabularx}
+  \begin{tabularx}{\textwidth}{|p{2.6cm}|X|p{1cm}|X|p{1.8cm}|X|}
+    指导教师姓名   & \AdvisorName & 职称 & 【这里填职称】 & 所在单位 & 【这里填单位】\\ \hline
+  \end{tabularx}
+  \begin{tabularx}{\textwidth}{|X|}
+    本科生毕业设计（论文）评阅意见：{\zihao{-5}（对论文选题、文献综述、外文翻译、研究内容与方法、创新点、论文质量与理论水平、论文写作规范与文风和修改建议等方面加以评阅）}\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    \hline
+  \end{tabularx}
+  \begin{tabularx}{\textwidth}{|X|p{1.5cm}|X|p{1.5cm}|X|p{1.5cm}|}
+    同意答辩    &  & 同意修改后答辩 &  & 未达到答辩要求 &        \\ \hline
+  \end{tabularx}
+  \begin{tabularx}{\textwidth}{|X|X|X|X|X|X|}
+    评阅人签名  &   & 评阅人职称     &  & 评阅人单位    &      \\ \hline
+  \end{tabularx}
+\end{center}
+
+\vfill
+
+\songti\zihao{5}注：请评阅专家经综合评价后，在相应栏内打“√”。

--- a/page/undergraduate/final/eeopinion.tex
+++ b/page/undergraduate/final/eeopinion.tex
@@ -9,6 +9,7 @@
 
 \songti\zihao{-4}
 \begin{center}
+  \begin{adjustbox}{minipage=16.83cm, center}
   \begin{tabularx}{\textwidth}{|p{4cm}|X|}
     \hline
     毕业设计（论文）题目 & \Title \\ \hline
@@ -42,12 +43,13 @@
     ~\\
     \hline
   \end{tabularx}
-  \begin{tabularx}{\textwidth}{|X|p{1.5cm}|X|p{1.5cm}|X|p{1.5cm}|}
+  \begin{tabularx}{\textwidth}{|p{2cm}|X|p{3cm}|X|p{3cm}|X|}
     同意答辩    &  & 同意修改后答辩 &  & 未达到答辩要求 &        \\ \hline
   \end{tabularx}
-  \begin{tabularx}{\textwidth}{|X|X|X|X|X|X|}
+  \begin{tabularx}{\textwidth}{|p{2.2cm}|X|p{2.2cm}|X|p{2.2cm}|X|}
     评阅人签名  &   & 评阅人职称     &  & 评阅人单位    &      \\ \hline
   \end{tabularx}
+\end{adjustbox}
 \end{center}
 
 \vfill

--- a/page/undergraduate/final/eerecord.tex
+++ b/page/undergraduate/final/eerecord.tex
@@ -1,0 +1,69 @@
+\thispagestyle{empty}
+\setcounter{page}{-1}
+
+\vskip 25mm
+
+\begin{center}
+  {\heiti\bfseries\zihao{-3} 浙江大学本科生毕业设计（论文）现场答辩记录表}
+  
+  \vskip 5mm
+
+  \begin{tabularx}{\textwidth}{>{\songti\bfseries\zihao{5}}X
+                               >{\songti\bfseries\zihao{5}}X<{\raggedleft}} 
+    学院：电气工程学院 & 毕业届别：2023 届
+  \end{tabularx}
+\end{center}
+
+\songti\zihao{-4}
+\begin{center}
+  \begin{tabularx}{\textwidth}{|p{2cm}|X|p{1cm}|X|p{1cm}|X|} \hline
+    学生姓名    & \StudentName & 学号 & \StudentID & 专业 & \Major   \\ \hline
+  \end{tabularx}
+
+  \begin{tabularx}{\textwidth}{|p{4cm}|X|}
+    毕业设计（论文）题目 & \Title \\ \hline
+  \end{tabularx}
+
+  \begin{tabularx}{\textwidth}{|p{2.6cm}|X|p{1.2cm}|X|p{1.8cm}|X|}
+    指导教师姓名   & \AdvisorName & 职~称 & 【这里填职称】 & 所在单位 & 【这里填单位】\\ \hline
+  \end{tabularx}
+
+  \begin{tabularx}{\textwidth}{|p{2.6cm}|X|p{2cm}|X|}
+    答辩时间    & 【填答辩时间】  & 答辩地点 & 【填答辩地点】  \\ \hline
+  \end{tabularx}
+
+  \begin{tabularx}{\textwidth}{|p{3.5cm}|X|}
+    答辩组成员（签名） & ~ \\ \hline
+  \end{tabularx}
+
+  \begin{tabularx}{\textwidth}{|X|}
+    本科生毕业设计（论文）答辩记录：{\zihao{5}（要求在答辩陈述和回答问题等方面具体加以记录与评价）}\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    ~\\
+    \begin{flushright}
+      \songti
+      \zihao{-4}
+      记录人（签名）： \multido{}{11}{\quad} \\
+      ~\\
+      \underline{\multido{}{4}{\quad}}年\underline{\quad\quad}月\underline{\quad\quad}日
+    \end{flushright}
+    ~\\
+    \begin{flushright}
+      \songti
+      \zihao{-4}
+      答辩小组负责人（签名）： \multido{}{9}{\quad} \\
+      ~\\
+      \underline{\multido{}{4}{\quad}}年\underline{\quad\quad}月\underline{\quad\quad}日
+    \end{flushright}
+    \\
+    \hline
+  \end{tabularx}
+\end{center}

--- a/page/undergraduate/final/eerecord.tex
+++ b/page/undergraduate/final/eerecord.tex
@@ -16,6 +16,7 @@
 
 \songti\zihao{-4}
 \begin{center}
+  \begin{adjustbox}{minipage=16.83cm, center}
   \begin{tabularx}{\textwidth}{|p{2cm}|X|p{1cm}|X|p{1cm}|X|} \hline
     学生姓名    & \StudentName & 学号 & \StudentID & 专业 & \Major   \\ \hline
   \end{tabularx}
@@ -24,8 +25,8 @@
     毕业设计（论文）题目 & \Title \\ \hline
   \end{tabularx}
 
-  \begin{tabularx}{\textwidth}{|p{2.6cm}|X|p{1.2cm}|X|p{1.8cm}|X|}
-    指导教师姓名   & \AdvisorName & 职~称 & 【这里填职称】 & 所在单位 & 【这里填单位】\\ \hline
+  \begin{tabularx}{\textwidth}{|p{2.6cm}|X|p{0.9cm}|X|p{1.7cm}|X|}
+    指导教师姓名   & \AdvisorName & 职称 & 【填职称】 & 所在单位 & 【填单位】\\ \hline
   \end{tabularx}
 
   \begin{tabularx}{\textwidth}{|p{2.6cm}|X|p{2cm}|X|}
@@ -38,7 +39,6 @@
 
   \begin{tabularx}{\textwidth}{|X|}
     本科生毕业设计（论文）答辩记录：{\zihao{5}（要求在答辩陈述和回答问题等方面具体加以记录与评价）}\\
-    ~\\
     ~\\
     ~\\
     ~\\
@@ -66,4 +66,5 @@
     \\
     \hline
   \end{tabularx}
+  \end{adjustbox}
 \end{center}

--- a/page/undergraduate/final/eval.tex
+++ b/page/undergraduate/final/eval.tex
@@ -1,7 +1,9 @@
 \cleardoublepage{}
 \ifthenelse{\equal{\MajorFormat}{ee}}
 {
-  \sectionnonum{毕~业~设~计（论文）~考~核~表}
+  \begin{center}
+    {\bfseries\fangsong\zihao{-2} 毕~业~设~计（论文）~考~核~表}
+  \end{center}
 }
 {
   \sectionnonum{本科生毕业论文（设计）考核}

--- a/page/undergraduate/final/eval.tex
+++ b/page/undergraduate/final/eval.tex
@@ -1,5 +1,11 @@
 \cleardoublepage{}
-\sectionnonum{本科生毕业论文（设计）考核}
+\ifthenelse{\equal{\MajorFormat}{ee}}
+{
+  \sectionnonum{毕~业~设~计（论文）~考~核~表}
+}
+{
+  \sectionnonum{本科生毕业论文（设计）考核}
+}
 
 {
     \bfseries
@@ -12,7 +18,13 @@
 
     \mbox{} \vfill
 
-    \finaleval[10][15][5][70][100]
-
-    \signature{负责人（签名）}
+    \ifthenelse{\equal{\MajorFormat}{ee}}
+    {
+      \eefinaleval[10][15][5][62][8][100]
+      \signature{答辩小组负责人（签名）}
+    }
+    {
+      \finaleval[10][15][5][70][100]
+      \signature{负责人（签名）}
+    }
 }

--- a/page/undergraduate/final/job.tex
+++ b/page/undergraduate/final/job.tex
@@ -1,12 +1,28 @@
 \cleardoublepage{}
-\sectionnonum{本科生毕业论文（设计）任务书}
+\ifthenelse{\equal{\MajorFormat}{ee}}
+{
+  \begin{center}
+    {\bfseries\fangsong\zihao{2} 本科生毕业论文（设计）任务书}
+  \end{center}
+}
+{
+  \sectionnonum{本科生毕业论文（设计）任务书}
+}
 
 {
     \bfseries
     \noindent 一、题目：\\
     \noindent 二、指导教师对毕业论文（设计）的进度安排及任务要求：\\
-
-    \vskip 50mm
+    \ifthenelse{\equal{\MajorFormat}{ee}}
+    {
+      \noindent 1、进度安排
+      \vskip 60mm
+      \noindent 2、任务要求
+      \vskip 40mm
+    }
+    {
+      \vskip 50mm
+    }
 
     \noindent 起讫日期 20 \quad 年 \quad  月 \quad  日 \quad 至 \quad 20 \quad  年 \quad  月  \quad 日
     \begin{flushright}

--- a/page/undergraduate/final/post.tex
+++ b/page/undergraduate/final/post.tex
@@ -2,3 +2,10 @@
 
 \inputpage{final/job}
 \inputpage{final/eval}
+\ifthenelse{\equal{\MajorFormat}{ee}}
+{
+  \newpage
+  \inputpage{final/eeopinion}
+  \newpage
+  \inputpage{final/eerecord}
+}{}

--- a/page/undergraduate/final/previous.tex
+++ b/page/undergraduate/final/previous.tex
@@ -1,3 +1,8 @@
+\ifthenelse{\equal{\MajorFormat}{ee}}
+{
+  \inputpage{final/eechecklist}
+  \newpage
+}{}
 \inputpage{final/promise}
 \ifthenelse{\equal{\BlindReview}{true}}{}{\inputbody{final/acknowledgement}}
 \inputbody{final/abstract}

--- a/page/undergraduate/proposal/cover.tex
+++ b/page/undergraduate/proposal/cover.tex
@@ -79,4 +79,15 @@
             }
         \end{tabularx}
     \end{center}
+
+  \ifthenelse{\equal{\MajorFormat}{ee}}
+  {    
+    \vskip 40pt
+
+    \zihao{4}
+    \begin{center}
+      \SubmitDate
+    \end{center}
+  }
+  {}
 }

--- a/zjuthesis.cls
+++ b/zjuthesis.cls
@@ -20,6 +20,8 @@
 \DeclareStringOption{Title}
 \DeclareStringOption{TitleEng}
 \DeclareStringOption{SubmitDate}
+\DeclareStringOption{Phone}
+\DeclareStringOption{Class}
 \DeclareStringOption[undergraduate]{Degree}
 \DeclareStringOption[general]{MajorFormat}
 \DeclareStringOption[thesis]{Type}

--- a/zjuthesis.tex
+++ b/zjuthesis.tex
@@ -64,11 +64,13 @@
 
         \prevstyle
         \inputpage{final/previous}
-        \inputpage{final/toc}
+        \ifthenelse{\equal{\MajorFormat}{ee}}
+        {}
+        {\inputpage{final/toc}}
 
         \bodystyle
         \ifthenelse{\equal{\MajorFormat}{ee}}
-        {}
+        {\inputpage{final/toc}}
         {
         \cleardoublepage
         \ifthenelse{\equal{\Type}{design}}

--- a/zjuthesis.tex
+++ b/zjuthesis.tex
@@ -32,6 +32,8 @@
     Period          = final,           % 'proposal' or 'paper' or 'final'
     BlindReview     = false,           % 'false'    or 'true'
     Language        = chinese,         % 'chinese'  or 'english'
+    Phone           = 12345678901,     % 11 digits
+    Class           = 班级,
     % Graduate Thesis Info
     GradLevel       = master,          % 'master' or 'doctor'
     Topic           = 研究方向,
@@ -65,17 +67,23 @@
         \inputpage{final/toc}
 
         \bodystyle
+        \ifthenelse{\equal{\MajorFormat}{ee}}
+        {}
+        {
         \cleardoublepage
         \ifthenelse{\equal{\Type}{design}}
             {\part{毕业设计}}
             {\part{毕业论文}}
-        
+        }
         \inputbody{final/content}
         \inputbody{final/post}
 
         \poststyle
         \inputpage{final/post}
 
+        \ifthenelse{\equal{\MajorFormat}{ee}}
+        {}
+        {
         % Proposal part
         \renewcommand{\undergradcurrstage}{proposal}
         \newrefsection
@@ -94,6 +102,7 @@
 
         \poststyle
         \inputpage{proposal/post}
+        }
     }
 
     \ifthenelse{\equal{\Period}{proposal}}


### PR DESCRIPTION
目前已完成开题报告的模板

    1. “参考文献”标题居中且不编号，在目录中不编号且与节标题同级。
       Affected files: `config/format/layout.tex`
    2. “开题报告考核表“居中，并增加一个“合计”栏目。
       Affected files: `commands.tex`
    3. 封面底部增加递交日期。
       Affected files: `cover.tex`
    4. 其他自定义选项，如增加`amsmath`包等，增加在`config/format/ee/`下。
       Affected files: `config/format/ee/*`