### PR TITLE
Fix compilation errors in undergrad template

### DIFF
--- a/config/commands.tex
+++ b/config/commands.tex
@@ -41,9 +41,9 @@
         %         undergraduate/cover.tex
         %         undergraduate/toc.tex
         %         undergraduate/major/ee/abstract.tex
-        \IfFileExists{./page/undergraduate/#1/\MajorFormat/#2}
+        \IfFileExists{./page/undergraduate/#1/major/\MajorFormat/#2}
         {
-            \input{./page/undergraduate/#1/\MajorFormat/#2}
+            \input{./page/undergraduate/#1/major/\MajorFormat/#2}
         }
         {
             \input{./page/undergraduate/#1/#2}

--- a/config/format/major/ee/README.md
+++ b/config/format/major/ee/README.md
@@ -1,6 +1,10 @@
-# 提交前检查
+# 使用说明
 
-在提交电气工程学院毕业设计（论文）前，请**务必检查以下条目是否完成**：
+**请务必对照学院下发的Word模板校对格式！！！**
+
+**注意**：在`zjuthesis.tex`中，如果`Period`选为`final`，将会编译出毕业论文**和**开题报告（以part的形式组织），如果仅需要打印毕业论文，可以将`Period`选为`paper`。
+
+在提交电气工程学院毕业设计（论文）前，请**检查以下条目是否完成**：
 
 - [ ] [page/undergraduate/final/major/ee/eechecklist.tex](../../../../page/undergraduate/final/major/ee/eechecklist.tex)：将`教师职称`和`分数`替换为相应内容
 - [ ] [page/undergraduate/final/major/ee/eeopinion.tex](../../../../page/undergraduate/final/major/ee/eeopinion.tex)：将`【这里填职称】`和`【这里填单位】`两处替换为相应内容
@@ -19,4 +23,4 @@
   {\noindent \textbf{Key words:} xxx, xxx, xxx, xxx}
   ```
 
-如果编译后发现表格的排版混乱，这是因为某些栏目的字数过多。可以考虑用`{\zihao{6}内容}`缩小字号以腾出空间，或者自己想办法调整表格列宽。
+如果编译后发现表格的排版混乱，这是因为某些栏目的字数过多。可以考虑用`{\zihao{6}内容}`缩小字号以腾出空间，或者自行调整表格列宽。

--- a/config/format/major/ee/README.md
+++ b/config/format/major/ee/README.md
@@ -1,9 +1,20 @@
-# 使用说明
-
 **请务必对照学院下发的Word模板校对格式！！！**
 
 **注意**：在`zjuthesis.tex`中，如果`Period`选为`final`，将会编译出毕业论文**和**开题报告（以part的形式组织），如果仅需要打印毕业论文，可以将`Period`选为`paper`。
 
+**注意**：本模板仅在Ubuntu下编译成功，Windows和MacOS下编译可能会由于新加入的华文行楷字体而出现问题。华文行楷的字体下载地址是https://github.com/chengda/popular-fonts/raw/master/%E5%8D%8E%E6%96%87%E8%A1%8C%E6%A5%B7.ttf，请自行下载安装（Windows和MacOS**可能**自带了华文行楷）。如果你在其他平台下编译失败，请删去[config/format/major/ee/fonts.tex](../ee/fonts.tex)这个文件，并将[page/undergraduate/final/major/ee/job.tex](../../../../page/undergraduate/final/major/ee/job.tex)中第四行的
+
+```latex
+  {\bfseries\hwxk\zihao{2} 本科生毕业论文（设计）任务书}
+```
+
+改为
+
+```latex
+  {\bfseries\zihao{2} 本科生毕业论文（设计）任务书}
+```
+
+---
 在提交电气工程学院毕业设计（论文）前，请**检查以下条目是否完成**：
 
 - [ ] [page/undergraduate/final/major/ee/eechecklist.tex](../../../../page/undergraduate/final/major/ee/eechecklist.tex)：将`教师职称`和`分数`替换为相应内容

--- a/config/format/major/ee/fonts.tex
+++ b/config/format/major/ee/fonts.tex
@@ -1,0 +1,2 @@
+\setCJKfamilyfont{hwxk}  {STXingkai}   [AutoFakeBold={\FakeBoldSize}]
+\newcommand*{\hwxk}{\CJKfamily{hwxk}}

--- a/config/format/major/ee/heading.tex
+++ b/config/format/major/ee/heading.tex
@@ -1,7 +1,7 @@
 % ctex style settings
 \ifthenelse{\equal{\Degree}{undergraduate}}
 {
-  \ifthenelse{\equal{\Period}{final}}{
+  \ifthenelse{\equal{\Period}{proposal}}{}{
     \ctexset
     {
         section = 
@@ -10,5 +10,5 @@
             name={第,章}
         }
     }
-  }{}
+  }
 }{}

--- a/config/format/major/ee/layout.tex
+++ b/config/format/major/ee/layout.tex
@@ -12,6 +12,9 @@
         {}
     }
     {
+      \setlength{\cftsecindent}       {0em}
+      \setlength{\cftsubsecindent}    {2em}
+      \setlength{\cftsubsubsecindent} {4em}
       \fancypagestyle{previous}
       {
           \fancyfoot{}

--- a/config/format/major/ee/packages.tex
+++ b/config/format/major/ee/packages.tex
@@ -1,2 +1,3 @@
 \usepackage{amsmath}
 \usepackage{adjustbox}
+\usepackage{ulem}

--- a/page/undergraduate/final/cover-part.tex
+++ b/page/undergraduate/final/cover-part.tex
@@ -1,4 +1,7 @@
-\cleardoublepage
-\ifthenelse{\equal{\Type}{design}}
-    {\part{毕业设计}}
-    {\part{毕业论文}}
+\ifthenelse{\equal{\Period}{final}}
+{%
+  \cleardoublepage
+  \ifthenelse{\equal{\Type}{design}}
+      {\part{毕业设计}}
+      {\part{毕业论文}}
+}{}

--- a/page/undergraduate/final/major/ee/cover-part.tex
+++ b/page/undergraduate/final/major/ee/cover-part.tex
@@ -1,5 +1,11 @@
-\inputpage{final}{toc}
 \cleardoublepage
-\ifthenelse{\equal{\Type}{design}}
-    {\part{毕业设计}}
-    {\part{毕业论文}}
+
+\tableofcontents
+
+\ifthenelse{\equal{\Period}{final}}
+{
+  \cleardoublepage
+  \ifthenelse{\equal{\Type}{design}}
+      {\part{毕业设计}}
+      {\part{毕业论文}}
+}{}

--- a/page/undergraduate/final/major/ee/eechecklist.tex
+++ b/page/undergraduate/final/major/ee/eechecklist.tex
@@ -7,7 +7,13 @@
 \begin{center}
   {\heiti\bfseries\zihao{3} 浙江大学本科生毕业设计（论文）装订内容检查表} \\ \vskip 2mm
   \songti\zihao{5} （此表请装订在论文首页，由指导教师在答辩结束后填写）\vskip 2mm
-  \eethesischecklistinfo[教师职称][分数]
+  \begin{tabularx}{\textwidth}{|X|X|X|X|X|X|}
+    \hline
+    学生姓名                      & \multicolumn{1}{p{2.1cm}|}{\songti \zihao{5}\StudentName}       & \multicolumn{1}{l|}{学号} & \StudentID & 专业年级小班               &   【填入】   \\ \hline
+    指导教师                      & \multicolumn{1}{l|}{\songti \zihao{5}\AdvisorName}              & \multicolumn{1}{l|}{职称} & 【填入】         & 学生联系电话               &   【填入】   \\ \hline
+    \multirow{2}{*}{毕业设计题目}  & \multicolumn{3}{l|}{\multirow{2}{*}{\songti \zihao{5}\Title}}                                           & \multirow{2}{*}{评定成绩} & \multirow{2}{*}{【分数】} \\
+                                 & \multicolumn{3}{l|}{}                                                                                   &                          &                   \\ \hline
+  \end{tabularx}
 \end{center}
 
 \vskip 15mm
@@ -37,4 +43,12 @@
 
 \vskip 20mm
 
-\eechecklistsig{检查人（签名）}
+\begin{center}
+  \songti
+  \zihao{-4}
+  检查人（签名） \underline{\multido{}{7}{\quad}}
+  \multido{}{3}{\quad} 
+  检查日期：\underline{\multido{}{7}{\quad}}
+\end{center}
+
+\cleardoublepage

--- a/page/undergraduate/final/major/ee/eval.tex
+++ b/page/undergraduate/final/major/ee/eval.tex
@@ -8,12 +8,22 @@
     \noindent 一、指导教师对毕业论文（设计）的评语：\\
     \vskip 50mm
 
-    \signature{指导教师（签名）}
+    % \signature{指导教师（签名）}
+    \begin{flushright}
+      \bfseries \zihao{-4}
+      指导教师（签名） \uwave{\quad\quad\quad\quad\quad} \\
+      \quad 年 \quad 月 \quad 日
+    \end{flushright}
 
     \noindent 二、答辩小组对毕业论文（设计）的答辩评语及总评成绩：\\
 
     \mbox{} \vfill
 
     \finaleval[10][15][5][62][8][100]
-    \signature{答辩小组负责人（签名）}
+    % \signature{答辩小组负责人（签名）}
+    \begin{flushright}
+      \bfseries \zihao{-4}
+      答辩小组负责人（签名） \uwave{\quad\quad\quad\quad\quad} \\
+      \quad 年 \quad 月 \quad 日
+    \end{flushright}
 }

--- a/page/undergraduate/final/major/ee/job.tex
+++ b/page/undergraduate/final/major/ee/job.tex
@@ -1,13 +1,8 @@
 \cleardoublepage{}
-\ifthenelse{\equal{\MajorFormat}{ee}}
-{
-  \begin{center}
-    {\bfseries\fangsong\zihao{2} 本科生毕业论文（设计）任务书}
-  \end{center}
-}
-{
-  \sectionnonum{本科生毕业论文（设计）任务书}
-}
+
+\begin{center}
+  {\bfseries\hwxk\zihao{2} 本科生毕业论文（设计）任务书}
+\end{center}
 
 {
     \bfseries
@@ -21,11 +16,17 @@
     \noindent 起讫日期 20 \quad 年 \quad  月 \quad  日 \quad 至 \quad 20 \quad  年 \quad  月  \quad 日
     \begin{flushright}
         \bfseries \zihao{-4}
-            指导教师（签名） \underline{\multido{}{5}{\quad}} 职称 \underline{\multido{}{5}{\quad}}
+            指导教师（签名） \uwave{\quad\quad\quad\quad\quad}
+            职称 \uwave{\quad\quad\quad\quad\quad}
     \end{flushright}
 
     \noindent 三、系或研究所审核意见：\\
 
     \mbox{} \vfill
-    \signature{负责人（签名）}
+    % \signature{负责人（签名）}
+    \begin{flushright}
+      \bfseries \zihao{-4}
+      负责人（签名） \uwave{\quad\quad\quad\quad\quad} \\
+      \quad 年 \quad 月 \quad 日
+    \end{flushright}
 }

--- a/page/undergraduate/final/major/ee/post.tex
+++ b/page/undergraduate/final/major/ee/post.tex
@@ -1,6 +1,6 @@
 \pagestyle{empty}
 
-\inputpage{final/job}
-\inputpage{final/eval}
-\inputpage{final/eeopinion}
-\inputpage{final/eerecord}
+\inputpage{final}{job}
+\inputpage{final}{eval}
+\inputpage{final}{eeopinion}
+\inputpage{final}{eerecord}

--- a/page/undergraduate/final/post.tex
+++ b/page/undergraduate/final/post.tex
@@ -1,4 +1,4 @@
 \pagestyle{empty}
 
-\inputpage{final/job}
-\inputpage{final/eval}
+\inputpage{final}{job}
+\inputpage{final}{eval}

--- a/page/undergraduate/final/previous.tex
+++ b/page/undergraduate/final/previous.tex
@@ -1,3 +1,3 @@
-\inputpage{final/promise}
+\inputpage{final}{promise}
 \ifthenelse{\equal{\BlindReview}{true}}{}{\inputbody{final/acknowledgement}}
 \inputbody{final/abstract}

--- a/page/undergraduate/proposal/design/post.tex
+++ b/page/undergraduate/proposal/design/post.tex
@@ -1,4 +1,4 @@
 \cleardoublepage
 
-\inputpage{proposal/design/proposaleval}
-\inputpage{proposal/design/midcheckeval}
+\inputpage{proposal}{design/proposaleval}
+\inputpage{proposal}{design/midcheckeval}

--- a/page/undergraduate/proposal/major/ee/cover.tex
+++ b/page/undergraduate/proposal/major/ee/cover.tex
@@ -8,17 +8,9 @@
 
 \begin{center}
     \zihao{-1} \heiti \bfseries
-    \ifthenelse{\equal{\Type}{thesis}}
-    {
-        本~~科~~生~~毕~~业~~论~~文
-        \\ \vskip 24pt
-        文献综述和开题报告
-    }
-    {
-        本~~科~~生~~毕~~业~~设~~计
-        \\ \vskip 24pt
-        开题报告
-    }
+    本~~科~~生~~毕~~业~~论~~文（论~~文）
+    \\ \vskip 24pt
+    文献综述和开题报告
 \end{center}
 
 \vskip 40pt

--- a/page/undergraduate/proposal/post.tex
+++ b/page/undergraduate/proposal/post.tex
@@ -2,8 +2,8 @@
 
 \ifthenelse{\equal{\Type}{design}}
 {
-    \inputpage{proposal/design/post}
+    \inputpage{proposal}{design/post}
 }
 {
-    \inputpage{proposal/thesis/post}
+    \inputpage{proposal}{thesis/post}
 }

--- a/page/undergraduate/proposal/previous.tex
+++ b/page/undergraduate/proposal/previous.tex
@@ -1,2 +1,2 @@
 \cleardoublepage
-\inputpage{proposal/\Type/previous}
+\inputpage{proposal}{\Type/previous}

--- a/page/undergraduate/proposal/thesis/post.tex
+++ b/page/undergraduate/proposal/thesis/post.tex
@@ -1,3 +1,3 @@
 \cleardoublepage{}
 
-\inputpage{proposal/thesis/proposaleval}
+\inputpage{proposal}{thesis/proposaleval}

--- a/zjuthesis.tex
+++ b/zjuthesis.tex
@@ -124,6 +124,7 @@
         \inputpage{final}{toc}
 
         \bodystyle
+        \inputpage{final}{cover-part}
         \cleardoublepage
         
         \inputbody{final/content}


### PR DESCRIPTION
- Fix compilation errors in the undergrad general template.
- Fix compilation problems in undergrad EE template.
- Add toc to EE undergrad final paper && Add cover-part to `paper`.   Include `cover-part` in `Period=paper` can make toc `bodystyle`.   To overcome `part` page, we can add an `if` clause.
