### PR TITLE
Update info about ZJU mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ zjuthesis 模板有三种使用方式，Overleaf，本地编译，或者 Contain
 
 ### 本地编译
 
-1. 安装 TeXLive 工具包，编译需要 XeTeX 引擎
+1. 安装 TeXLive 工具包，编译需要 XeTeX 引擎。安装过程可以参考[浙江大学镜像站提供的文档](https://mirrors.zju.edu.cn/docs/CTAN)，以便在校内网下更快下载。
 1. [下载模板代码](https://github.com/TheNetAdmin/zjuthesis/releases)，
    每个专业模板都有预览 pdf 文件，可以单独下载查看。
    模板代码请下载 `zjuthesis-v*.*.*.zip` 文件

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,10 +2,10 @@
 
 ## 使用
 
+1. 安装 TeXLive 工具包，编译需要 XeTeX 引擎。安装过程可以参考[浙江大学镜像站提供的文档](https://mirrors.zju.edu.cn/docs/CTAN)，以便在校内网下更快下载。
 1. [下载模板代码](https://github.com/TheNetAdmin/zjuthesis/releases)，
    每个专业模板都有预览 pdf 文件，可以单独下载查看。
    模板代码请下载 `zjuthesis-vx.x.x.zip` 文件。
-1. 安装 TeXLive 工具包，编译需要 XeTeX 引擎。安装所需的镜像文件可以选用浙江大学开源镜像站提供的[镜像](https://mirrors.zju.edu.cn/CTAN/systems/texlive/Images/)以便在校内网下更快下载。
 1. 在 `zjuthesis.tex` 中 `\documentclass[]{zjuthesis}` 部分填写个人信息，注意以下信息用于控制文档的生成：
 
    - `Degree` 为 `undergraduate` 时，编译本科生论文：


### PR DESCRIPTION
浙江大学镜像站近日进行了升级，添加了文档等功能。  
我注意到这个项目有跳转到浙江大学镜像站的链接，只不过之前是直接跳转到了 CTAN 的镜像目录里。
我觉得，如果可以直接跳转到 CTAN 帮助页面，可能会对同学们有更大的帮助。

这个 pr 的改动：
- 在 `usage.md` 中，将 CTAN 镜像目录的 url 改为 CTAN 文档页面
- 在 `README.md` 中，同步此修改

附：浙大镜像站 CTAN 帮助页面

![image](https://user-images.githubusercontent.com/19510622/226148182-89823298-34dc-4a9b-9151-e085107e568f.png)
![image](https://user-images.githubusercontent.com/19510622/226148212-61bb6c70-f695-47e4-bb2c-62606028c011.png)
![image](https://user-images.githubusercontent.com/19510622/226148204-cf14cc89-970c-49bb-b932-db5842dc2234.png)
