### PR TITLE
Feat: Add new period 'proposal_divided'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ zjuthesis 模板有三种使用方式，Overleaf，本地编译，或者 Contain
 
    - `Degree` 为 `undergraduate` 时，编译本科生论文：
 
-   | Field       | Option 1                             | Option 2                               | Option 3                           |
-   | :---------- | :----------------------------------- | :------------------------------------- | :--------------------------------- |
-   | Type        | thesis: 论文类                       | design: 设计类                         |                                    |
-   | Period      | proposal: 开题报告                   | final: 最终论文/设计（含开题报告）     | paper: 最终论文/报告（无开题报告） |
-   | BlindReview | true: 生成盲审用 pdf（隐藏个人信息） | false: 生成提交用 pdf                  |                                    |
+   | Field       | Option 1                             | Option 2                               | Option 3                           | Option 4                               |
+   | :---------- | :----------------------------------- | :------------------------------------- | :------------------------------------- | :------------------------------------- |
+   | Type        | thesis: 论文类                       | design: 设计类                         |                                    |                                    |
+   | Period      | proposal: 开题报告                    | final: 最终论文/设计（含开题报告）       | paper: 最终论文/报告（无开题报告）     | proposal_divided: 开题报告 (借助ProposalPart实现分别导出) |
+   | ProposalPart      | review: 仅生成文献综述                   | proposal: 仅生成开题报告     | translation: 仅生成文献翻译 | midcheck: 仅生成中期检查 |
+   | BlindReview | true: 生成盲审用 pdf（隐藏个人信息） | false: 生成提交用 pdf                  |                                    |                                    |
    | MajorFormat | general: 默认模板                    | 与 `config/format/major/` 下目录名相同 |                                    |
 
    - `Degree` 为 `graduate` 时，编译硕士生/博士生论文：

--- a/body/undergraduate/proposal/content.tex
+++ b/body/undergraduate/proposal/content.tex
@@ -1,23 +1,61 @@
 \cleardoublepage
 
-\ifthenelse{\equal{\Type}{thesis}}
+\ifthenelse{\equal{\Period}{proposal}}
 {
-    % `thesis` content
-    \inputbody{proposal/review/review}
-    \inputbody{proposal/proposal/proposal}
-    \inputbody{proposal/translation/translation}
-    \inputbody{proposal/original/original}
-}
+  \ifthenelse{\equal{\Type}{thesis}}
+  {
+      % `thesis` content
+      \inputbody{proposal/review/review}
+      \inputbody{proposal/proposal/proposal}
+      \inputbody{proposal/translation/translation}
+      \inputbody{proposal/original/original}
+  }
+  {
+      \ifthenelse{\equal{\Type}{design}}
+      {
+          % `design` content
+          \inputbody{proposal/proposal/proposal}
+          \inputbody{proposal/translation/translation}
+          \inputbody{proposal/original/original}
+          \inputbody{proposal/midcheck/midcheck}
+      }
+      {
+          % Wrong Input
+      }
+  }
+}{}
+\ifthenelse{\equal{\Period}{proposal_divided}}
 {
-    \ifthenelse{\equal{\Type}{design}}
+  \ifthenelse{\equal{\Type}{thesis}}
+  {
+    \ifthenelse{\equal{\ProposalPart}{review}}
     {
-        % `design` content
-        \inputbody{proposal/proposal/proposal}
-        \inputbody{proposal/translation/translation}
-        \inputbody{proposal/original/original}
-        \inputbody{proposal/midcheck/midcheck}
-    }
+      \inputbody{proposal/review/review}
+    }{}
+    \ifthenelse{\equal{\ProposalPart}{proposal}}
     {
-        % Wrong Input
-    }
-}
+      \inputbody{proposal/proposal/proposal}
+    }{}
+    \ifthenelse{\equal{\ProposalPart}{translation}}
+    {
+      \inputbody{proposal/translation/translation}
+      \inputbody{proposal/original/original}
+    }{}
+  }{}
+  \ifthenelse{\equal{\Type}{design}}
+  {
+    \ifthenelse{\equal{\ProposalPart}{proposal}}
+    {
+      \inputbody{proposal/proposal/proposal}
+    }{}
+    \ifthenelse{\equal{\ProposalPart}{translation}}
+    {
+      \inputbody{proposal/translation/translation}
+      \inputbody{proposal/original/original}
+    }{}
+    \ifthenelse{\equal{\ProposalPart}{midcheck}}
+    {
+      \inputbody{proposal/midcheck/midcheck}
+    }{}
+  }{}
+}{}

--- a/zjuthesis.cls
+++ b/zjuthesis.cls
@@ -24,6 +24,7 @@
 \DeclareStringOption[general]{MajorFormat}
 \DeclareStringOption[thesis]{Type}
 \DeclareStringOption[proposal]{Period}
+\DeclareStringOption{ProposalPart}
 \DeclareStringOption[chinese]{Language}
 \DeclareStringOption[doctor]{GradLevel}
 \DeclareStringOption{ColaboratorName}
@@ -37,6 +38,7 @@
 \wlog{MajorFormat: {\MajorFormat}}
 \wlog{Type: {\Type}}
 \wlog{Period: {\Period}}
+\wlog{ProposalPart: {\ProposalPart}}
 \wlog{BlindReview: {\BlindReview}}
 \wlog{Language: {\Language}}
 \wlog{GradLevel: {\GradLevel}}

--- a/zjuthesis.tex
+++ b/zjuthesis.tex
@@ -29,7 +29,8 @@
     MajorFormat     = general,
     Degree          = undergraduate,   % 'undergraduate' or 'graduate'
     Type            = thesis,          % 'thesis'   or 'design'
-    Period          = final,           % 'proposal' or 'paper' or 'final'
+    Period          = final,           % 'proposal' or 'paper' or 'final' or 'proposal_divided'
+    ProposalPart    = review,          % only for 'proposal_divided'. 'review' of 'proposal' or ' translation' or 'midcheck'.
     BlindReview     = false,           % 'false'    or 'true'
     Language        = chinese,         % 'chinese'  or 'english'
     % Graduate Thesis Info
@@ -108,6 +109,25 @@
         
         \poststyle
         \inputpage{proposal}{post}
+    }
+
+    \ifthenelse{\equal{\Period}{proposal_divided}}
+    {
+        % Thesis proposal
+        \newcommand{\undergradcurrstage}{proposal_divided}
+
+        \coverstyle
+        \inputpage{proposal}{cover}
+    
+        % 'proposal' previous part uses 'empty' page style,
+        % as shown in cs undergrad template.
+        \inputpage{proposal}{previous}
+        
+        \prevstyle
+        \inputpage{proposal}{toc}
+    
+        \bodystyle
+        \inputbody{proposal/content}
     }
 
     \ifthenelse{\equal{\Period}{paper}}


### PR DESCRIPTION
现代教务系统中提交开题报告处要求将三合一报告分开上传，并且在近期的校督导检查中，也提到了需要分别导出文献综述、外文翻译和开题报告三份文件后提交。
目前模板并不支持分别导出文献综述、外文翻译和开题报告，因此在`Period`中添加`proposal_divided`选项，在该选项的情况下，设置下方的`ProposalPart`即可指定单独导出的对象。

p.s. 对tex语法并不熟悉，修改后的代码可能不太美观，轻喷。