### PR TITLE
引用英文文献时，将\citeauthor默认的"et al."改为"等"

### DIFF
--- a/config/packages.tex
+++ b/config/packages.tex
@@ -13,7 +13,7 @@
 \usepackage{pdfpages}
 \usepackage[
     style=gb7714-2015,
-    gbcitelocal=chinese,   % Uncomment if you want \citeauthor{} in "et al." format. GitHub Issue 
+    gbcitelocal=chinese,   % Uncomment if you want \citeauthor{} in "et al." format. GitHub PR (#324)
     % gbpub=false,         % Uncomment if you do NOT want '[S.l. : s.n.]' in reference entries, GitHub Issue (#47)
     % gbnamefmt=lowercase, % Uncomment if you do NOT want uppercase author names in reference entries, GitHub Issue (#23)
 ]{biblatex}

--- a/config/packages.tex
+++ b/config/packages.tex
@@ -13,6 +13,7 @@
 \usepackage{pdfpages}
 \usepackage[
     style=gb7714-2015,
+    gbcitelocal=chinese,   % Uncomment if you want \citeauthor{} in "et al." format. GitHub Issue 
     % gbpub=false,         % Uncomment if you do NOT want '[S.l. : s.n.]' in reference entries, GitHub Issue (#47)
     % gbnamefmt=lowercase, % Uncomment if you do NOT want uppercase author names in reference entries, GitHub Issue (#23)
 ]{biblatex}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -83,7 +83,7 @@
 
    A: 使用 `\citeauthor{tikz}~\cite{tikz}` 即可。
 
-   如果需要对英文文献使用 `et al.` 的省略词，可以注释 `config/package.tex` 的 `biblatex` 包的 `gbcitelocal=chinese,` 一行。
+   如果需要对英文文献使用 `et al.` 的省略词，可以注释 `config/package.tex` 的 `biblatex` 包的 `gbcitelocal=chinese,` 一行。详见 [GitHub Pull Requests](https://github.com/TheNetAdmin/zjuthesis/pull/324)。
 
 ### 页眉与页脚
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -79,6 +79,12 @@
    
    如果需要“非全大写”姓名格式，请在引用 `biblatex` 包时指定 `gbnamefmt=lowercase`，详见 [GitHub Issue](https://github.com/TheNetAdmin/zjuthesis/issues/23#issuecomment-602129192) 讨论。
 
+1. Q: 怎样在文中引用文献作者?
+
+   A: 使用 `\citeauthor{tikz}~\cite{tikz}` 即可。
+
+   如果需要对英文文献使用 `et al.` 的省略词，可以注释 `config/package.tex` 的 `biblatex` 包的 `gbcitelocal=chinese,` 一行。
+
 ### 页眉与页脚
 
 1. Q: 如何定制页眉页脚（包括页码）？


### PR DESCRIPTION
引用英文文献时，若某文献中有多位作者，且想要使用 `\citeauthor` 自动引用文献作者，会出现"et al."，在中文论文中较为突兀。

因此，增加 `biblatex` 的 `gbcitelocal=chinese` 选项，将 `\citeauthor` 默认的 "et al." 改为 "等"。

并在 FAQ.md 中增加了相应说明