### PR TITLE
feat: add 3 lines title support

### DIFF
--- a/config/format/general/title.tex
+++ b/config/format/general/title.tex
@@ -2,8 +2,10 @@
 \newcommand{\TitleEngLines}{1}
 \newcommand{\TitleLineOne}{\Title}
 \newcommand{\TitleLineTwo}{~}
+\newcommand{\TitleLineThree}{~}
 \newcommand{\TitleEngLineOne}{\TitleEng}
 \newcommand{\TitleEngLineTwo}{~}
+\newcommand{\TitleEngLineThree}{~}
 \newcommand{\MajorLines}{1}
 \newcommand{\MajorLineOne}{\Major}
 \newcommand{\MajorLineTwo}{~}
@@ -17,10 +19,24 @@
     \renewcommand{\TitleLineTwo}{{#2}}
 }
 
+\newcommand{\titlethreelines}[3]{
+    \renewcommand{\TitleLines}{3}
+    \renewcommand{\TitleLineOne}{{#1}}
+    \renewcommand{\TitleLineTwo}{{#2}}
+    \renewcommand{\TitleLineThree}{{#3}}
+}
+
 \newcommand{\titleengtwolines}[2]{
     \renewcommand{\TitleEngLines}{2}
     \renewcommand{\TitleEngLineOne}{{#1}}
     \renewcommand{\TitleEngLineTwo}{{#2}}
+}
+
+\newcommand{\titleengthreelines}[3]{
+    \renewcommand{\TitleEngLines}{3}
+    \renewcommand{\TitleEngLineOne}{{#1}}
+    \renewcommand{\TitleEngLineTwo}{{#2}}
+    \renewcommand{\TitleEngLineThree}{{#3}}
 }
 
 \newcommand{\majortwolines}[2]{

--- a/page/graduate/cover-chn.tex
+++ b/page/graduate/cover-chn.tex
@@ -48,7 +48,13 @@
 
 % Define multi line title
 
-
+\ifnumcomp{\TitleLines+\TitleEngLines}{=}{5}{
+    \renewcommand{\arraystretch}{0.8}
+}{
+    \ifnumcomp{\TitleLines+\TitleEngLines}{=}{6}{
+        \renewcommand{\arraystretch}{0.65}
+    }
+}
 
 \begin{center}
     \bfseries \zihao{-2}
@@ -62,9 +68,18 @@
             ~ & \uline{\hfill} \\
         }
         {
-            % TitleLines == 2
-            中文论文题目：&  \uline{\hfill \fangsong \TitleLineOne{} \hfill} \\
-            ~            & \uline{\hfill \fangsong \TitleLineTwo{} \hfill} \\
+            \ifthenelse{\equal{\TitleLines}{2}}
+            {
+                % TitleLines == 2
+                中文论文题目：&  \uline{\hfill \fangsong \TitleLineOne{} \hfill} \\
+                ~            & \uline{\hfill \fangsong \TitleLineTwo{} \hfill} \\
+            }
+            {
+                % TitleLines == 3
+                中文论文题目：&  \uline{\hfill \fangsong \TitleLineOne{} \hfill} \\
+                ~            & \uline{\hfill \fangsong \TitleLineTwo{} \hfill} \\
+                ~            & \uline{\hfill \fangsong \TitleLineThree{} \hfill} \\
+            }
         }
 
         \ifthenelse{\equal{\TitleEngLines}{1}}
@@ -74,12 +89,23 @@
             ~ & \uline{\hfill} \\
         }
         {
-            % TitleEngLines == 2
-            英文论文题目：& \zihao{3} \uline{\hfill \TitleEngLineOne{} \hfill} \\
-            ~            & \zihao{3} \uline{\hfill \TitleEngLineTwo{} \hfill} \\
+            \ifthenelse{\equal{\TitleEngLines}{2}}
+            {
+                % TitleEngLines == 2
+                英文论文题目：& \zihao{3} \uline{\hfill \TitleEngLineOne{} \hfill} \\
+                ~            & \zihao{3} \uline{\hfill \TitleEngLineTwo{} \hfill} \\
+            }
+            {
+                % TitleEngLines == 3
+                英文论文题目：& \zihao{3} \uline{\hfill \TitleEngLineOne{} \hfill} \\
+                ~            & \zihao{3} \uline{\hfill \TitleEngLineTwo{} \hfill} \\
+                ~            & \zihao{3} \uline{\hfill \TitleEngLineThree{} \hfill} \\
+            }
         }
     \end{tabularx}
 \end{center}
+
+\renewcommand{\arraystretch}{1}
 
 \ifthenelse{\equal{\DepartmentLines}{1}}
 {

--- a/page/graduate/title-chn.tex
+++ b/page/graduate/title-chn.tex
@@ -1,5 +1,9 @@
 \cleardoublepage
 
+\ifnumcomp{\TitleLines}{=}{3}{
+    \renewcommand{\arraystretch}{0.75}
+}
+
 \begin{center}
     \bfseries \zihao{-2}
     \begin{tabularx}{.8\textwidth}{>{\fangsong}X<{\centering}}
@@ -10,12 +14,23 @@
             \uline{\hfill} \\
         }
         {
-            % TitleLines == 2
-            \uline{\hfill \fangsong \TitleLineOne{} \hfill} \\
-            \uline{\hfill \fangsong \TitleLineTwo{} \hfill} \\
+            \ifthenelse{\equal{\TitleLines}{2}}
+            {
+                % TitleLines == 2
+                \uline{\hfill \fangsong \TitleLineOne{} \hfill} \\
+                \uline{\hfill \fangsong \TitleLineTwo{} \hfill} \\
+            }
+            {
+                % TitleLines == 3
+                \uline{\hfill \fangsong \TitleLineOne{} \hfill} \\
+                \uline{\hfill \fangsong \TitleLineTwo{} \hfill} \\
+                \uline{\hfill \fangsong \TitleLineThree{} \hfill} \\
+            }
         }
     \end{tabularx}
 \end{center}
+
+\renewcommand{\arraystretch}{1}
 
 \vskip 20pt
 

--- a/page/graduate/title-eng.tex
+++ b/page/graduate/title-eng.tex
@@ -1,6 +1,10 @@
 \cleardoublepage
 
 {
+\ifnumcomp{\TitleLines}{=}{3}{
+    \renewcommand{\arraystretch}{0.65}
+}
+
 \begin{center}
     % Chinese zihao{3} == English 16pt
     \bfseries \zihao{3}
@@ -12,12 +16,24 @@
             \uline{\hfill} \\
         }
         {
-            % TitleEngLines == 2
-            \uline{\hfill \TitleEngLineOne{} \hfill} \\
-            \uline{\hfill \TitleEngLineTwo{} \hfill} \\
+            \ifthenelse{\equal{\TitleEngLines}{2}}
+            {
+                % TitleEngLines == 2
+                \uline{\hfill \TitleEngLineOne{} \hfill} \\
+                \uline{\hfill \TitleEngLineTwo{} \hfill} \\
+            }
+            {
+                % TitleEngLines == 3
+                \uline{\hfill \TitleEngLineOne{} \hfill} \\
+                \uline{\hfill \TitleEngLineTwo{} \hfill} \\
+                \uline{\hfill \TitleEngLineThree{} \hfill} \\
+            
+            }
         }
     \end{tabularx}
 \end{center}
+
+\renewcommand{\arraystretch}{1}
 
 \vskip 6pt
 

--- a/zjuthesis.tex
+++ b/zjuthesis.tex
@@ -49,6 +49,8 @@
 %% Uncomment the following lines if you need multi line titles on cover pages
 % \titletwolines{毕业论文题目第一行}{毕业论文题目第二行}
 % \titleengtwolines{English Title Line One}{English Title Line Two}
+% \titlethreelines{毕业论文题目第一行}{毕业论文题目第二行}{毕业论文题目第三行}
+% \titleengthreelines{English Title Line One}{English Title Line Two}{English Title Line Three}
 
 %% Uncomment the following lines if you need multi line major names on cover pages
 % \majortwolines{专业名第一行}{专业名第二行}


### PR DESCRIPTION
Follow #352 
添加了三行中英文标题的支持，为防止三行标题的引入导致封面和标题页超出一页，将标题的arraystretch暂时缩小使得整体页面不超出一页。