### PR TITLE
对 se 模板的 heading style 做简单的调整

### DIFF
--- a/config/format/major/se/heading.tex
+++ b/config/format/major/se/heading.tex
@@ -8,7 +8,35 @@
         chapter = 
         {
             format=\centering\zihao{-2}\bfseries,
-            name={第,章}
+            name={第,章},
+            beforeskip=0pt,
+            afterskip=16pt
+        },
+        section =
+        {
+            format=\raggedright\zihao{-3}\bfseries,
+            name={},
+            number=\arabic{chapter}.\arabic{section},
+            beforeskip=13pt,
+            afterskip=13pt
+        },
+        subsection =
+        {
+            format=\raggedright\zihao{4}\bfseries,
+            name={},
+            number=\arabic{chapter}.\arabic{section}.\arabic{subsection},
+            beforeskip=13pt,
+            afterskip=13pt
+        },
+        subsubsection =
+        {
+            format=\raggedright\zihao{-4}\bfseries,
+            name={},
+            aftername=\quad,
+            numbering=true,
+            number=\arabic{chapter}.\arabic{section}.\arabic{subsection}.\arabic{subsubsection},
+            beforeskip=0pt,
+            afterskip=0pt
         }
     }
 }


### PR DESCRIPTION
主要调整了：

- \chapter 段前和段后间距，使其更接近 word 模板
- 按照 word 模板的字号，调整了四种标题的字号
- 对 subsubsection 序号和标题之间的间隔进行了修改，由于 word 模板没定义这一节的格式，因此主要从美观的角度进行调整