### PR TITLE
feat: update devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,40 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/ubuntu/.devcontainer/base.Dockerfile
+FROM texlive/texlive:latest-full
+ARG TARGETOS TARGETARCH
 
-# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
-ARG VARIANT="ubuntu-22.04"
-FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
+ARG GITHUB_DOMAIN=gh-proxy.com/github.com
 
-# [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends texlive-full \
-    && sudo git clone https://github.com/Haixing-Hu/latex-chinese-fonts /usr/share/fonts/latex-chinese-fonts
+# starship
+RUN --mount=type=cache,target=/tmp \
+    curl -sSf https://starship.rs/install.sh | sh -s -- \
+        -y --base-url https://${GITHUB_DOMAIN}/starship/starship/releases
+RUN tee -a /etc/bash.bashrc <<"EOF"
+eval "$(starship init bash)"
+EOF
+
+# gosu
+RUN curl -Lo /usr/local/bin/gosu \
+    https://${GITHUB_DOMAIN}/tianon/gosu/releases/download/1.17/gosu-${TARGETARCH} && \
+    chmod +x /usr/local/bin/gosu
+
+# latex-chinese-fonts
+RUN --mount=type=cache,target=/tmp \
+    curl -Lo /tmp/latex-chinese-fonts.zip \
+        https://${GITHUB_DOMAIN}/Haixing-Hu/latex-chinese-fonts/archive/refs/heads/master.zip && \
+    unzip /tmp/latex-chinese-fonts.zip -d /usr/share/fonts/latex-chinese-fonts
+
+# create user
+ARG USERNAME=zjuer
+ARG GROUPNAME=zjuer
+RUN groupadd ${GROUPNAME} || true && \
+    useradd -g ${GROUPNAME} -m -s /bin/bash ${USERNAME} || true && \
+    usermod -aG sudo "${USERNAME}" && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# add entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+# default command
+ENV WORKSPACE=/workspace
+CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,18 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ubuntu
 {
-	"name": "Ubuntu",
+	"name": "zjuthesis",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { "VARIANT": "jammy" }
+		"context": "."
 	},
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"James-Yu.latex-workshop"
-	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
-
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"userEnvProbe": "loginInteractiveShell",
+	"remoteUser": "zjuer",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+	"workspaceFolder": "/workspace",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"James-Yu.latex-workshop"
+			]
+		}
+	}
 }

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+WORKSPACE=${WORKSPACE:-/workspace}
+
+echo "[*] Current workspace is $WORKSPACE."
+
+USERNAME=zjuer
+GROUPNAME=zjuer
+CURRENT_UID=$(id -u "$USERNAME" 2>/dev/null)
+CURRENT_GID=$(id -g "$USERNAME" 2>/dev/null)
+
+# Check if WORKSPACE or any parent directory is mounted
+current_dir="$WORKSPACE"
+is_mounted=false
+while [ "$current_dir" != "/" ]; do
+    if mountpoint -q "$current_dir"; then
+        echo "[*] $current_dir is a mount point."
+        is_mounted=true
+        break
+    fi
+    current_dir=$(dirname "$current_dir")
+done
+
+# After the loop, check the is_mounted flag
+if [ "$is_mounted" = true ]; then
+    HOST_UID=$(stat -c "%u" $WORKSPACE)
+    HOST_GID=$(stat -c "%g" $WORKSPACE)
+
+    if [ "$CURRENT_UID:$CURRENT_GID" != "$HOST_UID:$HOST_GID" ]; then
+        echo "[*] Current UID:GID ($CURRENT_UID:$CURRENT_GID) does not match host UID:GID ($HOST_UID:$HOST_GID) of $WORKSPACE."
+
+        echo "[*] Changing user $USERNAME:$GROUPNAME to $HOST_UID:$HOST_GID and chowning \"/home/${USERNAME}/\"..."
+        usermod -u "$HOST_UID" "$USERNAME"
+        groupmod -g "$HOST_GID" "$GROUPNAME"
+        chown -R "${USERNAME}:${GROUPNAME}" "/home/${USERNAME}"
+
+        echo "[*] ID Changed. Continuing as $USERNAME ($HOST_UID:$HOST_GID)."
+    else
+        echo "[*] User ID and group ID matched. Continuing as $USERNAME ($HOST_UID:$HOST_GID)."
+    fi
+else
+    echo "[!] $WORKSPACE is not mounted. Continuing as $USERNAME ($CURRENT_UID:$CURRENT_GID)."
+fi
+
+if [ -d "$WORKSPACE" ]; then
+    cd "$WORKSPACE"
+else
+    mkdir -p $WORKSPACE
+    chown -R $USERNAME:$GROUPNAME $WORKSPACE
+    cd $WORKSPACE
+fi
+
+exec gosu "$USERNAME" "$@"

--- a/README.md
+++ b/README.md
@@ -87,22 +87,34 @@ zjuthesis 模板有三种使用方式，Overleaf，本地编译，或者 Contain
 > - 本模板已经兼容 TeXLive 2021。TeXLive 2018 以及之前的版本复制伪粗体文字会产生乱码，建议使用本地 TeXLive 的同学使用最新版 TeXLive。
 > - 计算机专业的部分页面与学校通用格式不同，如果你是计算机专业的同学，请使用计算机专业的模板。
 
-### 使用容器编译
+### 在 Dev Containers 中使用
 
-本模板提供了一套配置文件，用以支持在容器中安装TeX Live，项目使用的字体，以及VS Code上的[LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop)插件，配合GitHub Codespaces可以做到开箱即用。感谢 [FUTURETECH6](https://github.com/FUTURETECH6) 同学贡献的[代码](https://github.com/TheNetAdmin/zjuthesis/pull/222)。
+本模板提供了一套配置文件，用以支持在 [Dev Containers](https://containers.dev/) 中安装 TeX Live，项目使用的字体，以及 VS Code上的 [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) 插件，以实现对本项目的开箱即用。感谢 [futuretech6](https://github.com/futuretech6) 同学贡献的[代码](https://github.com/TheNetAdmin/zjuthesis/pull/222)。
 
-GitHub Codespace使用方法：
+在本地 IDE 中使用 Dev Containers（主流 IDEs，如 JetBrains 系列等均支持 Dev Containers，此处以 VS Code作为示例）：
+
+1. 安装 [Dev Containers 插件](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+1. 执行 "Dev Containers: Reopen in Container" 指令（或点击界面左下角远程连接按钮并选择 "Reopen in Container"）
+1. 等待镜像编译[^ghproxy]完成后即可使用
+
+[^ghproxy]: 为了规避 GFW 影响，[Dockerfile](.devcontainer/Dockerfile#L4) 中使用了 [gh-proxy](https://gh-proxy.com/) 进行加速。若内容下载异常，可尝试修改 `ARG GITHUB_DOMAIN` 为其他 GitHub 代理或自行配置 docker-buildx 代理。
+
+<details>
+
+<summary>在 GitHub Codespace 使用 Dev Containers：</summary>
 
 1. 创建个人的项目（直接fork，或自行clone并修改remote）
 1. 在个人的项目主页点击"Code"
 1. 点击"Codespaces"
 1. 点击"New codespace"
-1. 等待容器构建（这一过程约要10分钟，因为要在标准Ubuntu的镜像中安装TeX Live）
+1. 等待容器构建（这一过程约要10分钟）
 1. 构建完成后，可以选择在VS Code（需要[GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces)插件）中或在浏览器中打开，然后按照在本地的使用方式使用
 
 > **注意**
 >
-> - 这一功能的初衷是为了方便性能较弱的设备（例如低功耗笔记本电脑）也能利用免费的云运算资源较快地完成编译，因此**不建议**在本地性能较强的机器上使用（请改用"本地编译"）。
+> - 使用 GitHub Codespace 功能的初衷是为了方便性能较弱的设备（例如低功耗笔记本电脑）也能利用云运算资源较快地完成编译，因此**不建议**在本地性能较强的机器上使用（请改用"本地编译" 或 "在本地 IDE 中使用 Dev Containers"）。
+
+</details>
 
 ### 字数统计
 


### PR DESCRIPTION
1. devcontainer.json 的语法标准变了很多了，需要进行修改
2. 另外，直接基于texlive官方镜像进行编译，加快了编译速度
3. 添加了本地 IDE 使用 [Dev Containers](https://containers.dev/) 的支持。现在 codespace 不能无限白嫖，所以在本地使用 Dev Containers 是最接近开箱即用的方式（同时也保留了对codespace的支持）