### PR TITLE
vscode: define LaTeX Workshop tools for latexmk recipes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
+    "latex-workshop.latex.tools": [
+        {
+            "name": "latexmk_rconly",
+            "command": "latexmk"
+        }
+    ],
     "latex-workshop.latex.recipes": [
         {
             "name": "latexmk (latexmkrc)",


### PR DESCRIPTION
这个 PR 修复了 VSCode + LaTeX Workshop 中 latexmk (latexmkrc) 配方“无反应”的问题：原配置引用了未定义的 latexmk_rconly tool，导致 toolchain 为空并被判定为无效。PR 在 .vscode/settings.json 中补充 latex-workshop.latex.tools，显式定义 latexmk_rconly，使配方能够正常调用 latexmk 并复用仓库内 .latexmkrc 的编译设置与 out/ 输出目录。