### PR TITLE
Fix: modify undergrad `\sectionnonum` & add `\sectionNonumNewpage`

### DIFF
--- a/config/commands.tex
+++ b/config/commands.tex
@@ -68,6 +68,16 @@
 
     \newcommand{\sectionnonum}[2][openright]
     {
+        \phantomsection
+        \addcontentsline{toc}{section}{#2}
+        \begin{center}
+            \bfseries \zihao{3} #2	
+        \end{center}	
+        \setcounter{subsection}{0}
+    }
+
+    \newcommand{\sectionNonumNewpage}[2][openright]
+    {
 
         \ifthenelse{\equal{\TwoSide}{true}}{
             \ifthenelse{\equal{#1}{openright}}


### PR DESCRIPTION
## Description
This PR modifies `config/commands.tex` under undergraduate case. Specifically, I avoid `\clearpage` or `\cleardoublepage` for command `\sectionnonum`, because this will better align with latex native command `\section`, which don't automatically clearpage.

To maintain original functionality, I rename the original new command `\sectionnonum` to `\sectionNonumNewpage`.

## Motivation
When compiling my proposal, I found in `body/undergraduate/proposal/original/original.tex` that, after `\chapter{外文翻译}` it will switch to next page to display original paper, which is not convenient. I also verify this in our official school template. Hence this PR.

## Verification
I successfully compiled my own proposal.